### PR TITLE
Fixed dtstart bug

### DIFF
--- a/lib/rrule.js
+++ b/lib/rrule.js
@@ -496,8 +496,9 @@ var RRule = function(options, noCache) {
 
     if (!opts.dtstart) {
         opts.dtstart = new Date();
-        opts.dtstart.setMilliseconds(0);
     }
+
+    opts.dtstart.setMilliseconds(0);
 
     if (opts.wkst === null) {
         opts.wkst = RRule.MO.weekday;


### PR DESCRIPTION
An exception caused by milliseconds in `dtstart`: the first date in rrule isn't dtstart

    var someDateString1 = '2014-05-21T03:06:09.187Z' // with milliseconds
    var someDateString2 = '2014-05-21T03:06:09.000Z'
    var rrule1 = new RRule({
        freq: RRule.DAILY,
        count: 3,
        dtstart: new Date(someDateString1)
    });
    var rrule2 = new RRule({
        freq: RRule.DAILY,
        count: 3,
        dtstart: new Date(someDateString2)
    });
    console.log(rrule1.all())
    // [Thu May 22 2014 11:06:09 GMT+0800 (CST), Fri May 23 2014 11:06:09 GMT+0800 (CST), Sat May 24 2014 11:06:09 GMT+0800 (CST)]
    console.log(rrule2.all())
    // [Wed May 21 2014 11:06:09 GMT+0800 (CST), Thu May 22 2014 11:06:09 GMT+0800 (CST), Fri May 23 2014 11:06:09 GMT+0800 (CST)]