### PR TITLE
Fixes issue #65

### DIFF
--- a/lib/rrule.js
+++ b/lib/rrule.js
@@ -123,8 +123,8 @@ var dateutil = {
         var unadjustedDate = new Date(millisecsFromBase);
         var unadjustedDateTzOffset = dateutil.tzOffset(unadjustedDate);
         var adjustedDate = new Date(millisecsFromBase + unadjustedDateTzOffset);
-        var adjustedDateOffset = dateutil.tzOffset(adjustedDate);
-        var finalDate = new Date(millisecsFromBase + adjustedDateOffset);
+        var adjustedDateTzOffset = dateutil.tzOffset(adjustedDate);
+        var finalDate = new Date(millisecsFromBase + adjustedDateTzOffset);
         return finalDate;
     },
 

--- a/lib/rrule.js
+++ b/lib/rrule.js
@@ -120,10 +120,12 @@ var dateutil = {
      */
     fromOrdinal: function(ordinal) {
         var millisecsFromBase = ordinal * dateutil.ONE_DAY;
-        return new Date(dateutil.ORDINAL_BASE.getTime()
-                        - dateutil.tzOffset(dateutil.ORDINAL_BASE)
-                        +  millisecsFromBase
-                        + dateutil.tzOffset(new Date(millisecsFromBase)));
+        var unadjustedDate = new Date(millisecsFromBase);
+        var unadjustedDateTzOffset = dateutil.tzOffset(unadjustedDate);
+        var adjustedDate = new Date(millisecsFromBase + unadjustedDateTzOffset);
+        var adjustedDateOffset = dateutil.tzOffset(adjustedDate);
+        var finalDate = new Date(millisecsFromBase + adjustedDateOffset);
+        return finalDate;
     },
 
     /**


### PR DESCRIPTION
dateutil.fromOrdinal does not correctly account for TZ offsets spanning a DST boundary.
