### PR TITLE
Accept DATE values for UNTIL/DTSTART

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,17 @@ iCalendar RFC. Only `freq` is required.
         </td>
     </tr>
     <tr>
+        <td><code>onlydate</code></td>
+        <td>This boolean flag, which is <code>false</code> by default, controls
+        whether <code>toString()</code> will output <code>until</code> and
+        <code>dtstart</code> including the time or not. When set to <code>false</code>,
+        <code>toString()</code> will generate <code>DATE-TIME</code> values, and
+        <code>DATE</code> when set to <code>true</code>. <code>fromString()</code>
+        will automatically set it depending on included <code>UNTIL</code> and
+        <code>DTSTART</code>, if present.
+        </td>
+    </tr>
+    <tr>
         <td><code>bysetpos</code></td>
         <td>If given, it must be either an integer, or a sequence of
             integers, positive or negative. Each given integer will specify

--- a/lib/rrule.js
+++ b/lib/rrule.js
@@ -182,9 +182,9 @@ var dateutil = {
         });
     },
 
-    timeToUntilString: function(time) {
+    timeToUntilString: function(time, onlyDate) {
         var date = new Date(time);
-        var comp, comps = [
+        var compsUsed, comp, comps = [
             date.getUTCFullYear(),
             date.getUTCMonth() + 1,
             date.getUTCDate(),
@@ -194,7 +194,15 @@ var dateutil = {
             date.getUTCSeconds(),
             'Z'
         ];
-        for (var i = 0; i < comps.length; i++) {
+
+        compsUsed = comps.length;
+        if (onlyDate) {
+          compsUsed = 3;
+        }
+
+        comps = comps.slice(0, compsUsed);
+
+        for (var i = 0; i < compsUsed; i++) {
             comp = comps[i];
             if (!/[TZ]/.test(comp) && comp < 10) {
                 comps[i] = '0' + String(comp);
@@ -217,6 +225,10 @@ var dateutil = {
             bits[6] || 0,
             bits[7] || 0
         ));
+    },
+
+    hasOnlyDate: function(until) {
+        return (!/T/.test(until));
     }
 
 };
@@ -711,6 +723,7 @@ RRule.DEFAULT_OPTIONS = {
     wkst:        RRule.MO,
     count:       null,
     until:       null,
+    onlydate:    false,
     bysetpos:    null,
     bymonth:     null,
     bymonthday:  null,
@@ -734,10 +747,12 @@ RRule.fromText = function(text, language) {
 };
 
 RRule.optionsToString = function(options) {
-    var key, keys, defaultKeys, value, strValues, pairs = [];
+    var key, keys, defaultKeys, value, strValues, onlyDate, pairs = [];
 
     keys = Object.keys(options);
     defaultKeys = Object.keys(RRule.DEFAULT_OPTIONS);
+
+    onlyDate = options.onlydate;
 
     for (var i = 0; i < keys.length; i++) {
 
@@ -789,7 +804,11 @@ RRule.optionsToString = function(options) {
                 break;
             case'DTSTART':
             case'UNTIL':
-                value = dateutil.timeToUntilString(value);
+                value = dateutil.timeToUntilString(value, onlyDate);
+                break;
+            case 'ONLYDATE':
+                // onlydate is just a flag
+                continue;
                 break;
             default:
                 if (value instanceof Array) {
@@ -1448,9 +1467,11 @@ RRule.parseString = function(rfcString) {
                 break;
             case 'DTSTART':
                 options.dtstart = dateutil.untilStringToDate(value);
+                options.onlydate = dateutil.hasOnlyDate(value);
                 break;
             case 'UNTIL':
                 options.until = dateutil.untilStringToDate(value);
+                options.onlydate = dateutil.hasOnlyDate(value);
                 break;
             case 'BYEASTER':
                 options.byeaster = Number(value);

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -59,8 +59,8 @@ test('fromText()', function() {
 strings = [
     ['FREQ=WEEKLY;UNTIL=20100101T000000Z', 'FREQ=WEEKLY;UNTIL=20100101T000000Z'],
 
-    // Parse also `date` but return `date-time`
-    ['FREQ=WEEKLY;UNTIL=20100101', 'FREQ=WEEKLY;UNTIL=20100101T000000Z']
+    // Detect that the original RRULE uses only dates
+    ['FREQ=WEEKLY;UNTIL=20100101', 'FREQ=WEEKLY;UNTIL=20100101']
 ];
 test('fromString()', function() {
     $.each(strings, function(){


### PR DESCRIPTION
When generating RRULEs to be used inside an iCalendar resource, the UNTIL and DTSTART parameters should match the original DTSTART value type, as per RFC 5545 (3.3.10. Recurrence Rule):

> The value of the UNTIL rule part MUST have the same
> value type as the "DTSTART" property

This pull request adds support for detecting and enabling the use of DATE values when using `toString()`. This is controlled in both ways:
- A new parameter `onlydate` is available. It is disabled by default, to match current behaviour.
- The `fromString()` method automatically detects if there is any UNTIL o DTSTART component, and sets `onlydate` according to current format.
