### PR TITLE
Bugfix

### DIFF
--- a/lib/rrule.js
+++ b/lib/rrule.js
@@ -756,7 +756,7 @@ RRule.optionsToString = function(options) {
                 value = RRule.FREQUENCIES[options.freq];
                 break;
             case 'WKST':
-                value = value.toString();
+                value = RRule[['MO', 'TU', 'WE', 'TH', 'FR', 'SA', 'SU'][value]].toString();
                 break;
             case 'BYWEEKDAY':
                 /*


### PR DESCRIPTION
Problem is that in options.wkst is kept a number and not a Weekday object. Therefore if wkst is set then we get wrong RFC string with 'WKST=0' when it should be 'WKST=MO' which makes parsedString = RRule.optionsToString(options) not parseable to RRule object again with RRule.fromString(parsedString) cause at line :1415 we have such assignment - options.wkst = RRule[value]; -  value === 0 in that instead of 'MO' and problem is that RRule[0] is non existent. And that makes code at line :520 accessible and it raises an Exception (TypeError: Cannot read property 'weekday' of undefined) as nor Weekday nor number nor null is stored in opts.wkst.