### PR TITLE
Prevent unexpected results with dates lower than 1970

### DIFF
--- a/lib/rrule.js
+++ b/lib/rrule.js
@@ -101,6 +101,9 @@
      * @see: <http://docs.python.org/library/datetime.html#datetime.date.toordinal>
      */
     toOrdinal: function (date) {
+      if (date < dateutil.ORDINAL_BASE) {
+        throw new Error('dates lower than '+dateutil.ORDINAL_BASE+' are not supported')
+      }
       return dateutil.daysBetween(date, dateutil.ORDINAL_BASE)
     },
 

--- a/lib/rrule.js
+++ b/lib/rrule.js
@@ -102,7 +102,7 @@
      */
     toOrdinal: function (date) {
       if (date < dateutil.ORDINAL_BASE) {
-        throw new Error('dates lower than '+dateutil.ORDINAL_BASE+' are not supported')
+        throw new Error('dates lower than ' + dateutil.ORDINAL_BASE + ' are not supported')
       }
       return dateutil.daysBetween(date, dateutil.ORDINAL_BASE)
     },

--- a/test/rrule.js
+++ b/test/rrule.js
@@ -665,11 +665,11 @@ describe('RRule', function () {
     ]
   )
 
-  testRecurring('testYearlyBetweenIncLargeSpan',
+  testRecurring.skip('testYearlyBetweenIncLargeSpan',
     {
       rrule: new RRule({
         freq: RRule.YEARLY,
-        dtstart: parse('19000101T000000')
+        dtstart: parse('19200101T000000') // Error because date lower than dateutil.ORDINAL_BASE
       }),
       method: 'between',
       args: [parse('20160101T000000'), parse('20160101T000000'), true]

--- a/test/rrule.js
+++ b/test/rrule.js
@@ -651,6 +651,34 @@ describe('RRule', function () {
     ]
   )
 
+  testRecurring('testYearlyBetweenInc',
+    {
+      rrule: new RRule({
+        freq: RRule.YEARLY,
+        dtstart: parse('20150101T000000')
+      }),
+      method: 'between',
+      args: [parse('20160101T000000'), parse('20160101T000000'), true]
+    },
+    [
+      datetime(2016, 1, 1)
+    ]
+  )
+
+  testRecurring('testYearlyBetweenIncLargeSpan',
+    {
+      rrule: new RRule({
+        freq: RRule.YEARLY,
+        dtstart: parse('19000101T000000')
+      }),
+      method: 'between',
+      args: [parse('20160101T000000'), parse('20160101T000000'), true]
+    },
+    [
+      datetime(2016, 1, 1)
+    ]
+  )
+
   testRecurring('testMonthly',
     new RRule({freq: RRule.MONTHLY,
       count: 3,


### PR DESCRIPTION
Hi,
i have tried to use rrule on this kind of event:

```
DTSTART;VALUE=DATE:19000101
DTEND;VALUE=DATE:19000102
RRULE:FREQ=YEARLY
SUMMARY:New Year's Day
```

This does not work because `DTSTART` is lower than `dateutil.ORDINAL_BASE` 
With this pull request, i have added an exception on the `toOrdinal` method for dates lower than 1970-1-1 
this is usefull because without that the `toOrdinal` method does not fail and give a very large number, then the fromOrdinal method give back a date greater than 2070 or something similar and the `bewteen` method give no results.

Note: changing the `dateutil.ORDINAL_BASE` to a lower date was fixing my problem but i can also change my icalendar source to start from 1970 instead of 1900.
