### PR TITLE
Add support for VALUE=DATE as a RDATE param

### DIFF
--- a/lib/rrule.js
+++ b/lib/rrule.js
@@ -2138,7 +2138,7 @@
           } else if (name === 'RDATE') {
             for (j = 0; j < parms.length; j++) {
               parm = parms[j]
-              if (parm !== 'VALUE=DATE-TIME') {
+              if (parm !== 'VALUE=DATE-TIME' && parm !== 'VALUE=DATE') {
                 throw new Error('unsupported RDATE parm: ' + parm)
               }
             }
@@ -2152,7 +2152,7 @@
           } else if (name === 'EXDATE') {
             for (j = 0; j < parms.length; j++) {
               parm = parms[j]
-              if (parm !== 'VALUE=DATE-TIME') {
+              if (parm !== 'VALUE=DATE-TIME' && parm !== 'VALUE=DATE') {
                 throw new Error('unsupported RDATE parm: ' + parm)
               }
             }


### PR DESCRIPTION
I checked other functions and it seems to me that simply allowing `VALUE=DATE` will work since the time part is optional in the parsing function.

References #127 
