### PR TITLE
For instances where there is only 1 frequency e.g. 'FREQ=1' in a RRule

### DIFF
--- a/lib/nlp.js
+++ b/lib/nlp.js
@@ -173,10 +173,12 @@
             .add(until.getDate() + ',')
             .add(until.getFullYear())
         } else if (this.options.count) {
-          this.add(gettext('for'))
-            .add(this.options.count)
-            .add(this.plural(this.options.count)
-              ? gettext('times') : gettext('time'))
+          this.add(this.options.count === 1
+            ? gettext('only')
+            : gettext('for'))
+              .add(this.options.count)
+              .add(this.plural(this.options.count)
+                ? gettext('times') : gettext('time'))
         }
 
         if (!this.isFullyConvertible()) this.add(gettext('(~ approximate)'))


### PR DESCRIPTION
For instances where there is only 1 frequency e.g. `FREQ=1` in a RRule/Exrule/Rdate/Exdate, the logic is changed to render `only` instead of `for`.

`Every Wednesday for 1 time` --> `Every Wednesday only 1 time`

I believe it adds a bit more clarity because saying Every indicates it will be a recurrence but in this case due to the frequency it is non-recurring.
