### PR TITLE
also allow UNTIL to be in localtime

### DIFF
--- a/lib/rrule.js
+++ b/lib/rrule.js
@@ -191,7 +191,7 @@
     },
 
     untilStringToDate: function (until) {
-      var re = /^(\d{4})(\d{2})(\d{2})(T(\d{2})(\d{2})(\d{2})Z)?$/
+      var re = /^(\d{4})(\d{2})(\d{2})(T(\d{2})(\d{2})(\d{2})Z?)?$/
       var bits = re.exec(until)
       if (!bits) throw new Error('Invalid UNTIL value: ' + until)
       return new Date(Date.UTC(


### PR DESCRIPTION
Make the 'Z' suffix optional, thereby allowing some broken CalDAV implementations
to interoperate. However, this would make the implementation non-compliant
with RFC2445

Fixes #145 
