### PR TITLE
Fix error with exdates excluding time to calculate hash if freq < HOURLY

### DIFF
--- a/lib/rrule.js
+++ b/lib/rrule.js
@@ -1102,7 +1102,11 @@
               date = dateutil.fromOrdinal(ii.yearordinal + i)
               for (k = 0; k < timeset.length; k++) {
                 time = timeset[k]
-                res = dateutil.combine(date, time)
+                if (freq < RRule.HOURLY){
+                  res = dateutil.combine(date, null)// time) // FIX EXDATE
+                } else {
+                  res = dateutil.combine(date, time)
+                }
                 if (until && res > until) {
                   this._len = total
                   return iterResult.getValue()

--- a/lib/rrule.js
+++ b/lib/rrule.js
@@ -1102,8 +1102,8 @@
               date = dateutil.fromOrdinal(ii.yearordinal + i)
               for (k = 0; k < timeset.length; k++) {
                 time = timeset[k]
-                if (freq < RRule.HOURLY){
-                  res = dateutil.combine(date, null)// time) // FIX EXDATE
+                if (freq < RRule.HOURLY) {
+                  res = dateutil.combine(date, null)
                 } else {
                   res = dateutil.combine(date, time)
                 }


### PR DESCRIPTION
When you compare a exdate with generated dates for .all() or .between(), rrule combined date and time and then calculate a hash to compare if the generated dates were the same than the exdates. If you are comparing only dates, you don't have to take care about time. The bug was that rrule asigned the now time to that date so hash calculation will be different.

Example: 
- exdate: 2016-01-05 00:00:00 +02:00
- date calculated: 2016-01-05 12:35:35 +02:00

So Number(exdate) !== Number(date calculated)
