### PR TITLE
Add fix for current date milliseconds

### DIFF
--- a/lib/rrule.js
+++ b/lib/rrule.js
@@ -465,7 +465,7 @@
     var opts = this.options = options
 
     if (opts.byeaster !== null) opts.freq = RRule.YEARLY
-    if (!opts.dtstart) opts.dtstart = new Date()
+    if (!opts.dtstart) opts.dtstart = new Date(new Date().setMilliseconds(0))
 
     var millisecondModulo = opts.dtstart.getTime() % 1000
     if (opts.wkst === null) {


### PR DESCRIPTION
When using a `RRuleSet` which rules don't specify `DTSTART`, the exrules do not exclude the matching rrules.

``` javascript
set = new RRuleSet()
rr = RRule.fromString("FREQ=WEEKLY;WKST=SU;BYDAY=MO;BYHOUR=12;BYMINUTE=0;BYSECOND=0")
ex = RRule.fromString("FREQ=WEEKLY;INTERVAL=2;WKST=SU;BYDAY=MO;BYHOUR=12;BYMINUTE=0;BYSECOND=0")
set.rrule(rr)
set.exrule(ex)
```

Previously, this:

```
set.between(new Date(), new Date() + 1000 * 60 * 60 * 24 * 365)
```

returned an array with days every week (like the exrule wasn't there), but not anymore now.

I'll write some tests later this week.
