### PR TITLE
fix WKST parameter value in rrule.toString()

### DIFF
--- a/lib/rrule.js
+++ b/lib/rrule.js
@@ -697,7 +697,7 @@
           value = RRule.FREQUENCIES[options.freq]
           break
         case 'WKST':
-          value = value.toString()
+          value = new Weekday(value).toString()
           break
         case 'BYWEEKDAY':
           /*

--- a/lib/rrule.js
+++ b/lib/rrule.js
@@ -697,7 +697,7 @@
           value = RRule.FREQUENCIES[options.freq]
           break
         case 'WKST':
-          value = new Weekday(value)
+          if (typeof value === 'number') value = new Weekday(value)
           break
         case 'BYWEEKDAY':
           /*

--- a/lib/rrule.js
+++ b/lib/rrule.js
@@ -697,7 +697,7 @@
           value = RRule.FREQUENCIES[options.freq]
           break
         case 'WKST':
-          value = new Weekday(value).toString()
+          value = new Weekday(value)
           break
         case 'BYWEEKDAY':
           /*


### PR DESCRIPTION
Returns a string value (one of `['MO', 'TU', 'WE', 'TH', 'FR', 'SA', 'SU']`) for WKST in `rrule.toString()` instead of a number.

resolves #187 