### PR TITLE
feat: Add support for ALLDAY rule

### DIFF
--- a/index.html
+++ b/index.html
@@ -150,6 +150,16 @@
         </tr>
         <tr>
             <th>
+                <div class="option-name"><code>allday</code>
+                </div>
+            </th>
+            <td>
+                  <label><input name="allday" type="radio" value="1" />true</label>
+                  <label><input name="allday" type="radio" value="0" />false</label>
+            </td>
+        </tr>
+        <tr>
+            <th>
                 <div class="option-name"><code>wkst</code>
 
                     <div class="help"> The week start day. Must be one of the

--- a/lib/rrule.js
+++ b/lib/rrule.js
@@ -169,7 +169,7 @@
       })
     },
 
-    timeToUntilString: function (time) {
+    timeToUntilString: function (time, allday) {
       var comp
       var date = new Date(time)
       var comps = [
@@ -187,7 +187,9 @@
         comp = comps[i]
         if (!/[TZ]/.test(comp) && comp < 10) comps[i] = '0' + String(comp)
       }
-      return comps.join('')
+
+      // if allday = true, use [yyyy, mm, dd]
+      return allday ? comps.splice(0, 3).join('') : comps.join('')
     },
 
     untilStringToDate: function (until) {
@@ -438,6 +440,10 @@
       between: []
     }
 
+    // Exclude allday
+    this._allday = options.allday
+    delete options.allday
+
     // used by toString()
     this.origOptions = {}
 
@@ -677,7 +683,7 @@
     return getnlp().fromText(text, language)
   }
 
-  RRule.optionsToString = function (options) {
+  RRule.optionsToString = function (options, allday) {
     var key, value, strValues
     var pairs = []
     var keys = Object.keys(options)
@@ -729,7 +735,7 @@
           break
         case 'DTSTART':
         case 'UNTIL':
-          value = dateutil.timeToUntilString(value)
+          value = dateutil.timeToUntilString(value, allday)
           break
         default:
           if (value instanceof Array) {
@@ -844,7 +850,7 @@
      * @return String
      */
     toString: function () {
-      return RRule.optionsToString(this.origOptions)
+      return RRule.optionsToString(this.origOptions, this._allday)
     },
 
     /**
@@ -1802,7 +1808,7 @@
       }
     },
 
-    valueOf: function () {
+    valueOf: function (allday) {
       var result = []
       if (this._rrule.length) {
         this._rrule.forEach(function (rrule) {
@@ -1811,7 +1817,7 @@
       }
       if (this._rdate.length) {
         result.push('RDATE:' + this._rdate.map(function (rdate) {
-          return dateutil.timeToUntilString(rdate)
+          return dateutil.timeToUntilString(rdate, allday)
         }).join(','))
       }
       if (this._exrule.length) {
@@ -1821,7 +1827,7 @@
       }
       if (this._exdate.length) {
         result.push('EXDATE:' + this._exdate.map(function (exdate) {
-          return dateutil.timeToUntilString(exdate)
+          return dateutil.timeToUntilString(exdate, allday)
         }).join(','))
       }
       return result

--- a/test/rrule.js
+++ b/test/rrule.js
@@ -3496,4 +3496,15 @@ describe('RRule', function () {
         'after dtstart , followed by before does not return dtstart')
     })
   })
+
+  it('testAllday', function () {
+    var date = new Date('2012-12-31')
+    var rr = new RRule({
+      freq: RRule.DAILY,
+      dtstart: date,
+      allday: true
+    })
+    assert.strictEqual(rr.toString(), 'FREQ=DAILY;DTSTART=20121231',
+      'the rule dtstart format yyyymmdd')
+  })
 })

--- a/test/rruleset.js
+++ b/test/rruleset.js
@@ -1,5 +1,6 @@
-/* global describe */
+/* global describe, it */
 
+var assert = require('assert')
 var utils = require('./lib/utils')
 var RRule = require('../')
 
@@ -343,4 +344,29 @@ describe('RRuleSet', function () {
       datetime(2007, 9, 2, 9, 0)
     ]
   )
+
+  it('testAllday', function () {
+    var date = new Date('2012-12-31')
+    var set = new RRuleSet()
+    var allday = true
+    var rr = new RRule({
+      freq: RRule.DAILY,
+      dtstart: date,
+      until: new Date('2013-01-05'),
+      allday: allday
+    })
+    set.rrule(rr)
+
+    assert.deepEqual(
+      set.valueOf(allday),
+      ['RRULE:FREQ=DAILY;DTSTART=20121231;UNTIL=20130105'],
+      set.valueOf(allday)
+    )
+
+    set.exdate(rr.after(date))
+    assert.deepEqual(set.valueOf(allday), [
+      'RRULE:FREQ=DAILY;DTSTART=20121231;UNTIL=20130105',
+      'EXDATE:20130101'
+    ], 'the rruleset.exdate format yyyymmdd')
+  })
 })


### PR DESCRIPTION
- Add `allday` argument to dateutil.timeToUntilString
- Add `allday` argument to RRuleset.valueOf
- Add `options.allday` to RRule constructor
- Add `allday` argument to RRule. optionsToString

when `allday=true`, the TIME format will use `yyyymmdd`.

```
var rrule = new RRule({
  freq: RRule.MONTHLY,
  dtstart: new Date('2012-12-31'),
  allday: true // options.allday
}) 

// allday = false: FREQ=MONTHLY;DTSTART=20121231T000000Z
rrule.toString() // 'FREQ=MONTHLY;DTSTART=20121231'
```