### PR TITLE
fix: isLeapYear only accepts integers instead of relying on instanceof to check the parameter type

### DIFF
--- a/lib/rrule.js
+++ b/lib/rrule.js
@@ -72,7 +72,6 @@
     },
 
     isLeapYear: function (year) {
-      if (year instanceof Date) year = year.getFullYear()
       return ((year % 4 === 0) && (year % 100 !== 0)) || (year % 400 === 0)
     },
 
@@ -128,7 +127,7 @@
 
     getMonthDays: function (date) {
       var month = date.getMonth()
-      return month === 1 && dateutil.isLeapYear(date)
+      return month === 1 && dateutil.isLeapYear(date.getFullYear())
         ? 29 : dateutil.MONTH_DAYS[month]
     },
 


### PR DESCRIPTION
Fixes issues with testing frameworks that override the native Date object

See issue https://github.com/jakubroztocil/rrule/issues/197