### PR TITLE
Allow using 0 to represent Monday for byweekday

### DIFF
--- a/lib/nlp.js
+++ b/lib/nlp.js
@@ -76,7 +76,7 @@
         if (!this.bymonthday.length) this.bymonthday = null
       }
 
-      if (this.origOptions.byweekday) {
+      if (this.origOptions.byweekday !== null) {
         var byweekday = !(this.origOptions.byweekday instanceof Array)
           ? [this.origOptions.byweekday] : this.origOptions.byweekday
         var days = String(byweekday)


### PR DESCRIPTION
0 is falsy, so if `byweekday` was set to 0 to represent Monday, the text output would be incorrect.

Fixes #153.