### PR TITLE
BUG: The first instance of a reccuring event after end of daylight saving time is one day to early

### DIFF
--- a/lib/rrule.js
+++ b/lib/rrule.js
@@ -100,9 +100,6 @@
      * @see: <http://docs.python.org/library/datetime.html#datetime.date.toordinal>
      */
     toOrdinal: function (date) {
-      if (date < dateutil.ORDINAL_BASE) {
-        throw new Error('dates lower than ' + dateutil.ORDINAL_BASE + ' are not supported')
-      }
       return dateutil.daysBetween(date, dateutil.ORDINAL_BASE)
     },
 

--- a/lib/rrule.js
+++ b/lib/rrule.js
@@ -51,9 +51,9 @@
     /**
      * Python uses 1-Jan-1 as the base for calculating ordinals but we don't
      * want to confuse the JS engine with milliseconds > Number.MAX_NUMBER,
-     * therefore we use 1-Jan-1900 instead
+     * therefore we use 1-Jan-1970 instead
      */
-    ORDINAL_BASE: new Date(1900, 0, 1),
+    ORDINAL_BASE: new Date(1970, 0, 1),
 
     /**
      * Python: MO-SU: 0 - 6


### PR DESCRIPTION
Dump: FREQ=WEEKLY;DTSTART=20181003T080000Z;COUNT=10;WKST=MO;BYDAY=WE
1	Wed	Oct	03	2018	10:00:00	GMT+0200	(Mitteleuropäische	Sommerzeit)
2	Wed	Oct	10	2018	10:00:00	GMT+0200	(Mitteleuropäische	Sommerzeit)
3	Wed	Oct	17	2018	10:00:00	GMT+0200	(Mitteleuropäische	Sommerzeit)
4	Wed	Oct	24	2018	10:00:00	GMT+0200	(Mitteleuropäische	Sommerzeit)
5	Tue	Oct	30	2018	10:00:00	GMT+0100	(Mitteleuropäische	Zeit)
6	Wed	Nov	07	2018	10:00:00	GMT+0100	(Mitteleuropäische	Zeit)
7	Wed	Nov	14	2018	10:00:00	GMT+0100	(Mitteleuropäische	Zeit)
8	Wed	Nov	21	2018	10:00:00	GMT+0100	(Mitteleuropäische	Zeit)
9	Wed	Nov	28	2018	10:00:00	GMT+0100	(Mitteleuropäische	Zeit)
10	Wed	Dec	05	2018	10:00:00	GMT+0100	(Mitteleuropäische	Zeit)