### PR TITLE
Add typings for `rrulestr`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -172,6 +172,18 @@ declare namespace RRule {
 
     function fromString(value: string): RRule;
 
+    function rrulestr(s: string, options?: RRuleStrOptions): RRule;
+
+    interface RRuleStrOptions {
+        dtstart?: Date;
+        cache?: boolean;
+        unfold?: boolean;
+        forceset?: boolean;
+        compatible?: boolean;
+        ignoretz?: boolean;
+        tzinfos?: any;
+    }
+
     class RRuleSet extends RRule {
       /**
       *

--- a/index.d.ts
+++ b/index.d.ts
@@ -172,7 +172,7 @@ declare namespace RRule {
 
     function fromString(value: string): RRule;
 
-    function rrulestr(s: string, options?: RRuleStrOptions): RRule;
+    function rrulestr(s: string, options?: RRuleStrOptions): RRule | RRuleSet;
 
     interface RRuleStrOptions {
         dtstart?: Date;


### PR DESCRIPTION
Fixes #216. The `tzinfos` option is left untyped because it is not used at all due to the lack of timezone support. (See #45.)