### PR TITLE
removed time zone offset from fromOrdinal method

### DIFF
--- a/src/dateutil.js
+++ b/src/dateutil.js
@@ -75,11 +75,7 @@ const dateutil = {
    * @see - <http://docs.python.org/library/datetime.html#datetime.date.fromordinal>
    */
   fromOrdinal: function (ordinal) {
-    const millisecsFromBase = ordinal * dateutil.ONE_DAY
-    return new Date(dateutil.ORDINAL_BASE.getTime() -
-      dateutil.tzOffset(dateutil.ORDINAL_BASE) +
-      millisecsFromBase +
-      dateutil.tzOffset(new Date(millisecsFromBase)))
+   return new Date(dateutil.ORDINAL_BASE.getTime() + (ordinal * dateutil.ONE_DAY))
   },
 
   /**


### PR DESCRIPTION
In dateutil.js, the method fromOrdinal (lines 77-83) does not need to subtract and then re-add the time zone offset. When the time zone of the ORINDAL_BASE and passed in ordinal value are the same, the net result is 0 anyway. But in the case of time zones that go on and off daylight savings time, like Eastern time zone, the time zone offset for the ORDINAL_BASE and the time zone offset for the passed in ordinal value will be different when the ordinal date is in daylight savings and the ORDINAL_BASE is not, resulting in a date value that is 1 hour less than what it should be.