### PR TITLE
Point main back to es5 version

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,7 @@
     "rfc"
   ],
   "author": "Jakub Roztocil and Lars Schöning",
-  "main": "dist/es6",
-  "module": "dist/es6",
+  "main": "dist/es5",
   "repository": {
     "type": "git",
     "url": "git://github.com/jakubroztocil/rrule.git"


### PR DESCRIPTION
Version 2.3.x now points to ES6 sources which is a breaking change, as when we upgraded rrule in our app it broke IE11 support as it doesn't support ES6 classes. Also removed the `module` field because the es6 source isn't transpiled to es2015 modules / it's standard for the module field to point to ES5 transpiled code + es2015 modules. Let me know if you need any more info and thanks for all the work you're doing on this package! 👍 