### PR TITLE
add sourceRoot of dist to fix mapping warnings

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,8 @@
     "target": "es5",
     "jsx": "react",
     "strictNullChecks": true,
-    "rootDirs": ["./src/", "./test/"]
+    "rootDirs": ["./src/", "./test/"],
+    "sourceRoot": "./dist/esm"
   },
   "include": ["./src/**/*"],
   "exclude": ["node_modules", "./test/**/*"]


### PR DESCRIPTION
This will ensure .map file sources are set to the dist folder, rather than the src folder. Fixes #303

---

### Thanks for contributing to `rrule`!

To submit a pull request, please verify that you have done the following:

- [x] Merged in or rebased on the latest `master` commit
- [x] Linked to an existing bug or issue describing the bug or feature you're
      addressing
- [ ] Written one or more tests showing that your change works as advertised
- [x] Run `yarn build` to rebuild the `dist/` files
