### PR TITLE
Add a quick way to format 'until' in toText

### DIFF
--- a/src/nlp/index.ts
+++ b/src/nlp/index.ts
@@ -1,4 +1,4 @@
-import ToText, { GetText } from './totext'
+import ToText, { DateFormatter, GetText } from './totext'
 import parseText from './parsetext'
 import RRule from '../index'
 import ENGLISH, { Language } from './i18n'
@@ -119,8 +119,8 @@ ToText.IMPLEMENTED[RRule.YEARLY] = ['byweekno', 'byyearday'].concat(common)
 // Export
 // =============================================================================
 
-const toText = function (rrule: RRule, gettext?: GetText, language?: Language) {
-  return new ToText(rrule, gettext, language).toString()
+const toText = function (rrule: RRule, gettext?: GetText, language?: Language, dateFormatter?: DateFormatter) {
+  return new ToText(rrule, gettext, language, dateFormatter).toString()
 }
 
 const { isFullyConvertible } = ToText

--- a/src/nlp/totext.ts
+++ b/src/nlp/totext.ts
@@ -23,6 +23,10 @@ export type GetText = (id: string | number | Weekday) => string
 
 const defaultGetText: GetText = id => id.toString()
 
+export type DateFormatter = (year: number, month: string, day: number) => string
+
+const defaultDateFormatter: DateFormatter = (year: number, month: string, day: number) => `${month} ${day}, ${year}`
+
 /**
  *
  * @param {RRule} rrule
@@ -36,6 +40,7 @@ export default class ToText {
   private rrule: RRule
   private text: string[]
   private gettext: GetText
+  private dateFormatter: DateFormatter
   private language: Language
   private options: Partial<Options>
   private origOptions: Partial<Options>
@@ -47,11 +52,11 @@ export default class ToText {
     isEveryDay: boolean
   } | null
 
-  constructor (rrule: RRule, gettext: GetText = defaultGetText, language: Language = ENGLISH) {
+  constructor (rrule: RRule, gettext: GetText = defaultGetText, language: Language = ENGLISH, dateFormatter: DateFormatter = defaultDateFormatter) {
     this.text = []
     this.language = language || ENGLISH
     this.gettext = gettext
-
+    this.dateFormatter = dateFormatter
     this.rrule = rrule
     this.options = rrule.options
     this.origOptions = rrule.origOptions
@@ -155,9 +160,7 @@ export default class ToText {
     if (this.options.until) {
       this.add(gettext('until'))
       const until = this.options.until
-      this.add(this.language.monthNames[until.getUTCMonth()])
-        .add(until.getUTCDate() + ',')
-        .add(until.getUTCFullYear().toString())
+      this.add(this.dateFormatter(until.getUTCFullYear(), this.language.monthNames[until.getUTCMonth()], until.getUTCDate()))
     } else if (this.options.count) {
       this.add(gettext('for'))
         .add(this.options.count.toString())

--- a/src/rrule.ts
+++ b/src/rrule.ts
@@ -4,7 +4,7 @@ import IterResult, { IterArgs } from './iterresult'
 import CallbackIterResult from './callbackiterresult'
 import { Language } from './nlp/i18n'
 import { Nlp } from './nlp/index'
-import { GetText } from './nlp/totext'
+import { DateFormatter, GetText } from './nlp/totext'
 import { ParsedOptions, Options, Frequency, QueryMethods, QueryMethodTypes } from './types'
 import { parseOptions, initializeOptions } from './parseoptions'
 import { parseString } from './parsestring'
@@ -255,8 +255,8 @@ export default class RRule implements QueryMethods {
    * Will convert all rules described in nlp:ToText
    * to text.
    */
-  toText (gettext?: GetText, language?: Language) {
-    return getnlp().toText(this, gettext, language)
+  toText (gettext?: GetText, language?: Language, dateFormatter?: DateFormatter) {
+    return getnlp().toText(this, gettext, language, dateFormatter)
   }
 
   isFullyConvertibleToText () {

--- a/test/nlp.test.ts
+++ b/test/nlp.test.ts
@@ -1,6 +1,8 @@
 import { expect } from 'chai'
+import { DateTime } from 'luxon'
 import RRule from '../src';
 import { optionsToString } from '../src/optionstostring';
+import {DateFormatter} from '../src/nlp/totext'
 
 const texts = [
   ['Every day', 'RRULE:FREQ=DAILY'],
@@ -73,5 +75,25 @@ describe('NLP', () => {
     ]}
     const rule = new RRule(options)
     expect(rule.toText()).to.equal('every day')
+  })
+
+  it('by default formats \'until\' correctly', () => {
+    const rrule = new RRule({
+      freq: RRule.WEEKLY,
+      until: DateTime.utc(2012, 11, 10).toJSDate()
+    })
+
+    expect(rrule.toText()).to.equal('every week until November 10, 2012')
+  })
+
+  it('formats \'until\' as desired if asked', () => {
+    const rrule = new RRule({
+      freq: RRule.WEEKLY,
+      until: DateTime.utc(2012, 11, 10).toJSDate()
+    })
+
+    const dateFormatter: DateFormatter = (year, month, day) => `${day}. ${month}, ${year}`
+
+    expect(rrule.toText(undefined, undefined, dateFormatter)).to.equal('every week until 10. November, 2012')
   })
 })


### PR DESCRIPTION
It's not the most beautiful of ways, essentially adding an optional argument to `RRule.toText`, but with NLP being split out, it seemed like an okay stopgap for now. I'd have preferred adding a method to the Language interface, but I couldn't without either breaking existing Language implementations (compile-time only, though), or making a new sub interface. This seemed a bit cleaner.

Fixes #312

---

### Thanks for contributing to `rrule`!

To submit a pull request, please verify that you have done the following:

- [x] Merged in or rebased on the latest `master` commit
- [x] Linked to an existing bug or issue describing the bug or feature you're
      addressing
- [x] Written one or more tests showing that your change works as advertised
- [x] Run `yarn build` to rebuild the `dist/` files
