### PR TITLE
Add support for parsing an rrule string without frequency

### DIFF
--- a/src/rruleset.ts
+++ b/src/rruleset.ts
@@ -6,6 +6,25 @@ import { iterSet } from './iterset'
 import { QueryMethodTypes, IterResultType } from './types'
 import { optionsToString } from './optionstostring'
 
+function createGetterSetter <T> (fieldName: string) {
+  return (field?: T) => {
+    if (field !== undefined) {
+      this[`_${fieldName}`] = field
+    }
+
+    if (this[`_${fieldName}`] !== undefined) {
+      return this[`_${fieldName}`]
+    }
+
+    for (let i = 0; i < this._rrule.length; i++) {
+      const field: T = this._rrule[i].origOptions[fieldName]
+      if (field) {
+        return field
+      }
+    }
+  }
+}
+
 export default class RRuleSet extends RRule {
   public readonly _rrule: RRule[]
   public readonly _rdate: Date[]
@@ -30,27 +49,8 @@ export default class RRuleSet extends RRule {
     this._exdate = []
   }
 
-  dtstart (dtstart?: Date | null | undefined) {
-    this._dtstart = dtstart
-  }
-
-  tzid (tzid?: string) {
-    if (tzid !== undefined) {
-      this._tzid = tzid
-    }
-
-    if (this._tzid !== undefined) {
-      return this._tzid
-    }
-
-    for (let i = 0; i < this._rrule.length; i++) {
-      const tzid = this._rrule[i].origOptions.tzid
-      if (tzid) {
-        return tzid
-      }
-    }
-    return undefined
-  }
+  dtstart = createGetterSetter.apply(this, ['dtstart'])
+  tzid = createGetterSetter.apply(this, ['tzid'])
 
   _iter <M extends QueryMethodTypes> (iterResult: IterResult<M>): IterResultType<M> {
     return iterSet(

--- a/src/rruleset.ts
+++ b/src/rruleset.ts
@@ -4,12 +4,15 @@ import { includes } from './helpers'
 import IterResult from './iterresult'
 import { iterSet } from './iterset'
 import { QueryMethodTypes, IterResultType } from './types'
+import { optionsToString } from './optionstostring'
 
 export default class RRuleSet extends RRule {
   public readonly _rrule: RRule[]
   public readonly _rdate: Date[]
   public readonly _exrule: RRule[]
   public readonly _exdate: Date[]
+
+  private _dtstart?: Date | null | undefined
   private _tzid?: string
 
   /**
@@ -25,6 +28,10 @@ export default class RRuleSet extends RRule {
     this._rdate = []
     this._exrule = []
     this._exdate = []
+  }
+
+  dtstart (dtstart?: Date | null | undefined) {
+    this._dtstart = dtstart
   }
 
   tzid (tzid?: string) {
@@ -94,6 +101,11 @@ export default class RRuleSet extends RRule {
 
   valueOf () {
     let result: string[] = []
+
+    if (!this._rrule.length && this._dtstart) {
+      result = result.concat(optionsToString({ dtstart: this._dtstart }))
+    }
+
     this._rrule.forEach(function (rrule) {
       result = result.concat(rrule.toString().split('\n'))
     })

--- a/src/rrulestr.ts
+++ b/src/rrulestr.ts
@@ -113,6 +113,8 @@ function buildRule (s: string, options: Partial<RRuleStrOptions>) {
     exdatevals.length
   ) {
     const rset = new RRuleSet(noCache)
+
+    rset.dtstart(dtstart)
     rset.tzid(tzid || undefined)
 
     rrulevals.forEach(val => {
@@ -145,7 +147,7 @@ function buildRule (s: string, options: Partial<RRuleStrOptions>) {
     return rset
   }
 
-  const val = rrulevals[0]
+  const val = rrulevals[0] || {}
   return new RRule(groomRruleOptions(
     val,
     val.dtstart || options.dtstart || dtstart,

--- a/test/rrulestr.test.ts
+++ b/test/rrulestr.test.ts
@@ -26,6 +26,17 @@ describe('rrulestr', function () {
     )).to.be.instanceof(RRule)
   })
 
+  it('parses an rrule without frequency', () => {
+    const rRuleString = 'DTSTART:19970902T090000Z';
+    const parsedRRuleSet = rrulestr(
+      rRuleString, { forceset: true }
+    ) as RRuleSet;
+    expect(parsedRRuleSet.toString()).to.be.equal(rRuleString);
+
+    const parsedRRule = rrulestr(rRuleString) as RRule;
+    expect(parsedRRule.toString()).to.be.equal(rRuleString);
+  })
+
   it('parses an rruleset when forceset=true', () => {
     expect(rrulestr(
       'DTSTART:19970902T090000Z\n' +


### PR DESCRIPTION
Prior to this PR, `rrulestr` fails to parse a simple RRule of `"DTSTART:X"`.

- As an RRule, `rrulevals` becomes empty and `groomRruleOptions` spreads an undefined value.
- As an RRuleSet, `dtstart` is parsed and only ever used if the parsed RRule string contains a frequency component (`"RRULE:Y"`).

This PR stores the parsed DTSTART as a field on an RRuleSet which may be changed using the new `dtstart`-setter. The DTSTART component is only printed if `RRuleSet._dtstart` is set and `RRuleSet._rrule` is an empty array to avoid conflicting outputs.

- [x] Merged in or rebased on the latest `master` commit
- [ ] Linked to an existing bug or issue describing the bug or feature you're
      addressing (- I hope the description here is enough)
- [x] Written one or more tests showing that your change works as advertised
- [x] Run `yarn build` to rebuild the `dist/` files


edit:

FYI, with the changes in e1146a3, `RRuleSet.tzid()` and `RRuleSet.dtstart()` lose their type signatures. These may be recovered by upgrading TypeScript to 3.2+ with the `strictBindCallApply`-option.