### PR TITLE
Add getters for rrules, exrules, rdates, exdates

### DIFF
--- a/README.md
+++ b/README.md
@@ -680,6 +680,22 @@ Same as `RRule.prototype.before`.
 
 Same as `RRule.prototype.after`.
 
+##### `RRuleSet.prototype.rrules()`
+
+Get list of included rrules in this recurrence set.
+
+##### `RRuleSet.prototype.exrules()`
+
+Get list of excluded rrules in this recurrence set.
+
+##### `RRuleSet.prototype.rdates()`
+
+Get list of included datetimes in this recurrence set.
+
+##### `RRuleSet.prototype.exdates()`
+
+Get list of excluded datetimes in this recurrence set.
+
 * * * * *
 
 #### `rrulestr` Function

--- a/src/rruleset.ts
+++ b/src/rruleset.ts
@@ -93,7 +93,7 @@ export default class RRuleSet extends RRule {
   }
 
   /**
-   * Get list of rrules in this RRuleSet
+   * Get list of included rrules in this recurrence set.
    *
    * @return List of rrules
    */
@@ -102,7 +102,7 @@ export default class RRuleSet extends RRule {
   }
 
   /**
-   * Get list of exrules in this RRuleSet
+   * Get list of excluded rrules in this recurrence set.
    *
    * @return List of exrules
    */
@@ -111,7 +111,7 @@ export default class RRuleSet extends RRule {
   }
 
   /**
-   * Get list of rdates in this RRuleSet
+   * Get list of included datetimes in this recurrence set.
    *
    * @return List of rdates
    */
@@ -120,7 +120,7 @@ export default class RRuleSet extends RRule {
   }
 
   /**
-   * Get list of exdates in this RRuleSet
+   * Get list of included datetimes in this recurrence set.
    *
    * @return List of exdates
    */

--- a/src/rruleset.ts
+++ b/src/rruleset.ts
@@ -4,6 +4,7 @@ import { includes } from './helpers'
 import IterResult from './iterresult'
 import { iterSet } from './iterset'
 import { QueryMethodTypes, IterResultType } from './types'
+import { rrulestr } from './rrulestr';
 
 export default class RRuleSet extends RRule {
   public readonly _rrule: RRule[]
@@ -98,7 +99,7 @@ export default class RRuleSet extends RRule {
    * @return List of rrules
    */
   rrules () {
-    return this._rrule
+    return this._rrule.map(e => rrulestr(e.toString()))
   }
 
   /**
@@ -107,7 +108,7 @@ export default class RRuleSet extends RRule {
    * @return List of exrules
    */
   exrules () {
-    return this._exrule
+    return this._exrule.map(e => rrulestr(e.toString()))
   }
 
   /**
@@ -116,7 +117,7 @@ export default class RRuleSet extends RRule {
    * @return List of rdates
    */
   rdates () {
-    return this._rdate
+    return this._rdate.map(e => new Date(e.getTime()))
   }
 
   /**
@@ -125,7 +126,7 @@ export default class RRuleSet extends RRule {
    * @return List of exdates
    */
   exdates () {
-    return this._exdate
+    return this._exdate.map(e => new Date(e.getTime()))
   }
 
   valueOf () {

--- a/src/rruleset.ts
+++ b/src/rruleset.ts
@@ -4,7 +4,7 @@ import { includes } from './helpers'
 import IterResult from './iterresult'
 import { iterSet } from './iterset'
 import { QueryMethodTypes, IterResultType } from './types'
-import { rrulestr } from './rrulestr';
+import { rrulestr } from './rrulestr'
 
 export default class RRuleSet extends RRule {
   public readonly _rrule: RRule[]

--- a/src/rruleset.ts
+++ b/src/rruleset.ts
@@ -92,6 +92,42 @@ export default class RRuleSet extends RRule {
     _addDate(date, this._exdate)
   }
 
+  /**
+   * Get list of rrules in this RRuleSet
+   *
+   * @return List of rrules
+   */
+  rrules () {
+    return this._rrule
+  }
+
+  /**
+   * Get list of exrules in this RRuleSet
+   *
+   * @return List of exrules
+   */
+  exrules () {
+    return this._exrule
+  }
+
+  /**
+   * Get list of rdates in this RRuleSet
+   *
+   * @return List of rdates
+   */
+  rdates () {
+    return this._rdate
+  }
+
+  /**
+   * Get list of exdates in this RRuleSet
+   *
+   * @return List of exdates
+   */
+  exdates () {
+    return this._exdate
+  }
+
   valueOf () {
     let result: string[] = []
     this._rrule.forEach(function (rrule) {

--- a/test/rruleset.test.ts
+++ b/test/rruleset.test.ts
@@ -739,7 +739,7 @@ describe('RRuleSet', function () {
       });
       set.rrule(rrule);
 
-      expect(set.rrules()).eql([rrule]);
+      expect(set.rrules().map(e => e.toString())).eql([rrule.toString()]);
     });
     it('exrules()', () => {
       let set = new RRuleSet();
@@ -751,13 +751,13 @@ describe('RRuleSet', function () {
       });
       set.exrule(rrule);
 
-      expect(set.exrules()).eql([rrule]);
+      expect(set.exrules().map(e => e.toString())).eql([rrule.toString()]);
     });
     it('rdates()', () => {
       let set = new RRuleSet();
       let dt = parse('19610201T090000');
       set.rdate(dt);
-
+      
       expect(set.rdates()).eql([dt]);
     });
     it('exdates()', () => {

--- a/test/rruleset.test.ts
+++ b/test/rruleset.test.ts
@@ -727,4 +727,45 @@ describe('RRuleSet', function () {
     expect(() => set.rdate('foo' as any)).to.throw()
     expect(() => set.exdate('foo' as any)).to.throw()
   })
-})
+
+  describe('getters', () => {
+    it('rrules()', () => {
+      let set = new RRuleSet();
+      let rrule = new RRule({
+        freq: RRule.YEARLY,
+        count: 2,
+        dtstart: parse('19600101T090000'),
+        tzid: 'America/New_York'
+      });
+      set.rrule(rrule);
+
+      expect(set.rrules()).eql([rrule]);
+    });
+    it('exrules()', () => {
+      let set = new RRuleSet();
+      let rrule = new RRule({
+        freq: RRule.YEARLY,
+        count: 2,
+        dtstart: parse('19600101T090000'),
+        tzid: 'America/New_York'
+      });
+      set.exrule(rrule);
+
+      expect(set.exrules()).eql([rrule]);
+    });
+    it('rdates()', () => {
+      let set = new RRuleSet();
+      let dt = parse('19610201T090000');
+      set.rdate(dt);
+
+      expect(set.rdates()).eql([dt]);
+    });
+    it('exdates()', () => {
+      let set = new RRuleSet();
+      let dt = parse('19610201T090000');
+      set.exdate(dt);
+
+      expect(set.exdates()).eql([dt]);
+    });
+  });
+});

--- a/test/rruleset.test.ts
+++ b/test/rruleset.test.ts
@@ -741,6 +741,7 @@ describe('RRuleSet', function () {
 
       expect(set.rrules().map(e => e.toString())).eql([rrule.toString()]);
     });
+    
     it('exrules()', () => {
       let set = new RRuleSet();
       let rrule = new RRule({
@@ -753,6 +754,7 @@ describe('RRuleSet', function () {
 
       expect(set.exrules().map(e => e.toString())).eql([rrule.toString()]);
     });
+
     it('rdates()', () => {
       let set = new RRuleSet();
       let dt = parse('19610201T090000');
@@ -760,6 +762,7 @@ describe('RRuleSet', function () {
       
       expect(set.rdates()).eql([dt]);
     });
+
     it('exdates()', () => {
       let set = new RRuleSet();
       let dt = parse('19610201T090000');


### PR DESCRIPTION
---
- Add getters for rrules, exrules, rdates, exdates. That way we have a public API to accomplish the issue that https://github.com/jakubroztocil/rrule/issues/212 is describing.

### Thanks for contributing to `rrule`!

To submit a pull request, please verify that you have done the following:

- [x] Merged in or rebased on the latest `master` commit
- [x] Linked to an existing bug or issue describing the bug or feature you're
      addressing
- [x] Written one or more tests showing that your change works as advertised
- [ ] Run `yarn build` to rebuild the `dist/` files
