### PR TITLE
Remove dist files checkbox from PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,4 +8,3 @@ To submit a pull request, please verify that you have done the following:
 - [ ] Linked to an existing bug or issue describing the bug or feature you're
       addressing
 - [ ] Written one or more tests showing that your change works as advertised
-- [ ] Run `yarn build` to rebuild the `dist/` files


### PR DESCRIPTION
It seems like this is not necessary, since there is no longer a "dist" directory checked in to the repo. [At the time of the creation of this file](https://github.com/jakubroztocil/rrule/tree/555bed1d3a081b25c86e03f7b4ffdebd4019e10e), though, there was a "dist" directory.