### PR TITLE
Change precommit to "yarn lint"

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "yarn build"
+      "pre-commit": "yarn lint"
     }
   },
   "scripts": {


### PR DESCRIPTION
---

This just helps with committing -- otherwise commits take a pretty long time when everything is actually built. I don't think we need to have `yarn build` running after every commit given that there's already CI set up.


### Thanks for contributing to `rrule`!

To submit a pull request, please verify that you have done the following:

- [ ] Merged in or rebased on the latest `master` commit
- [ ] Linked to an existing bug or issue describing the bug or feature you're
      addressing
- [ ] Written one or more tests showing that your change works as advertised
