### PR TITLE
Break after until

### DIFF
--- a/src/iter/index.ts
+++ b/src/iter/index.ts
@@ -24,6 +24,7 @@ export function iter <M extends QueryMethodTypes> (iterResult: IterResult<M>, op
   }
 
   let counterDate = DateTime.fromDate(dtstart)
+  const endYear = until ? DateTime.fromDate(until).year : dateutil.MAXYEAR
 
   const ii = new Iterinfo(options)
   ii.rebuild(counterDate.year, counterDate.month)
@@ -100,8 +101,11 @@ export function iter <M extends QueryMethodTypes> (iterResult: IterResult<M>, op
     // Handle frequency and interval
     counterDate.add(options, filtered)
 
-    if (counterDate.year > dateutil.MAXYEAR) {
-      return emitResult(iterResult)
+    if (counterDate) {
+
+      if (counterDate.year > endYear) {
+        return emitResult(iterResult)
+      }
     }
 
     if (!freqIsDailyOrGreater(freq)) {


### PR DESCRIPTION
Daily repeating entries can hang the browser when querying between.

Fix to use the until parameter to prevent this happening

---

### Thanks for contributing to `rrule`!

To submit a pull request, please verify that you have done the following:

- [X] Merged in or rebased on the latest `master` commit
- [] Linked to an existing bug or issue describing the bug or feature you're
      addressing
- [ ] Written one or more tests showing that your change works as advertised
