### PR TITLE
Do not rezone dates to prevent doubly applying offset. Accommodate relevant tests.

### DIFF
--- a/src/datewithzone.ts
+++ b/src/datewithzone.ts
@@ -26,24 +26,4 @@ export class DateWithZone {
   public getTime () {
     return this.date.getTime()
   }
-
-  public rezonedDate () {
-    if (this.isUTC) {
-      return this.date
-    }
-
-    try {
-      const datetime = DateTime
-        .fromJSDate(this.date)
-
-      const rezoned = datetime.setZone(this.tzid!, { keepLocalTime: true })
-
-      return rezoned.toJSDate()
-    } catch (e) {
-      if (e instanceof TypeError) {
-        console.error('Using TZID without Luxon available is unsupported. Returned times are in UTC, not the requested time zone')
-      }
-      return this.date
-    }
-  }
 }

--- a/src/iter/index.ts
+++ b/src/iter/index.ts
@@ -5,7 +5,6 @@ import Iterinfo from '../iterinfo/index'
 import RRule from '../rrule'
 import { buildTimeset } from '../parseoptions'
 import { notEmpty, includes, isPresent } from '../helpers'
-import { DateWithZone } from '../datewithzone'
 import { buildPoslist } from './poslist'
 import { Time, DateTime } from '../datetime'
 
@@ -49,8 +48,7 @@ export function iter <M extends QueryMethodTypes> (iterResult: IterResult<M>, op
         }
 
         if (res >= dtstart) {
-          const rezonedDate = rezoneIfNeeded(res, options)
-          if (!iterResult.accept(rezonedDate)) {
+          if (!iterResult.accept(res)) {
             return emitResult(iterResult)
           }
 
@@ -78,8 +76,7 @@ export function iter <M extends QueryMethodTypes> (iterResult: IterResult<M>, op
           }
 
           if (res >= dtstart) {
-            const rezonedDate = rezoneIfNeeded(res, options)
-            if (!iterResult.accept(rezonedDate)) {
+            if (!iterResult.accept(res)) {
               return emitResult(iterResult)
             }
 
@@ -144,10 +141,6 @@ function isFiltered (
           !includes(byyearday, currentDay + 1 - ii.yearlen) &&
           !includes(byyearday, -ii.nextyearlen + currentDay - ii.yearlen))))
   )
-}
-
-function rezoneIfNeeded (date: Date, options: ParsedOptions) {
-  return new DateWithZone(date, options.tzid).rezonedDate()
 }
 
 function emitResult <M extends QueryMethodTypes> (iterResult: IterResult<M>) {

--- a/src/iterset.ts
+++ b/src/iterset.ts
@@ -1,6 +1,5 @@
 import IterResult from './iterresult'
 import RRule from './rrule'
-import { DateWithZone } from './datewithzone'
 import { iter } from './iter/index'
 import dateutil from './dateutil'
 import { QueryMethodTypes, IterResultType } from './types'
@@ -25,8 +24,7 @@ export function iterSet <M extends QueryMethodTypes> (
   }
 
   _exdate.forEach(function (date) {
-    const zonedDate = new DateWithZone(date, tzid).rezonedDate()
-    _exdateHash[Number(zonedDate)] = true
+    _exdateHash[Number(date)] = true
   })
 
   iterResult.accept = function (date) {
@@ -54,8 +52,7 @@ export function iterSet <M extends QueryMethodTypes> (
   }
 
   for (let i = 0; i < _rdate.length; i++) {
-    const zonedDate = new DateWithZone(_rdate[i], tzid).rezonedDate()
-    if (!iterResult.accept(new Date(zonedDate.getTime()))) break
+    if (!iterResult.accept(new Date(_rdate[i].getTime()))) break
   }
 
   _rrule.forEach(function (rrule) {

--- a/test/datewithzone.test.ts
+++ b/test/datewithzone.test.ts
@@ -1,8 +1,5 @@
 import { DateWithZone } from "../src/datewithzone";
 import { expect } from "chai";
-import { DateTime } from "luxon";
-import { set as setMockDate, reset as resetMockDate } from 'mockdate'
-import { expectedDate } from "./lib/utils";
 
 describe('toString', () => {
   it('returns the date when no tzid is present', () => {
@@ -23,44 +20,4 @@ it('returns the time of the date', () => {
   const d = new Date(Date.UTC(2010, 9, 5, 11, 0, 0))
   const dt = new DateWithZone(d)
   expect(dt.getTime()).to.equal(d.getTime())
-})
-
-describe('rezonedDate', () => {
-  it('returns the original date when no zone is given', () => {
-    const d = new Date(Date.UTC(2010, 9, 5, 11, 0, 0))
-    const dt = new DateWithZone(d)
-    expect(dt.rezonedDate()).to.deep.equal(d)
-  })
-
-  it('returns the date in the correct zone when given', () => {
-    const targetZone = 'America/New_York'
-    const currentLocalDate = DateTime.local(2000, 2, 6, 1, 0, 0)
-    setMockDate(currentLocalDate.toJSDate())
-
-    const d = DateTime.fromISO('20101005T110000').toJSDate()
-    const dt = new DateWithZone(d, targetZone)
-    expect(dt.rezonedDate()).to.deep.equal(
-      expectedDate(DateTime.fromISO('20101005T110000'), currentLocalDate, targetZone)
-    )
-
-    resetMockDate()
-  })
-
-  it('recovers from an error if Luxon is missing', () => {
-    const origfromJSDate = DateTime.fromJSDate
-    DateTime.fromJSDate = () => {
-      throw new TypeError()
-    }
-
-    const targetZone = 'America/New_York'
-    const currentLocalDate = DateTime.local(2000, 2, 6, 1, 0, 0)
-    setMockDate(currentLocalDate.toJSDate())
-
-    const d = DateTime.fromISO('20101005T110000').toJSDate()
-    const dt = new DateWithZone(d, targetZone)
-    expect(dt.rezonedDate()).to.deep.equal(d)
-
-    DateTime.fromJSDate = origfromJSDate
-    resetMockDate()
-  })
 })

--- a/test/lib/utils.ts
+++ b/test/lib/utils.ts
@@ -194,16 +194,3 @@ testRecurring.only = function (...args) {
 testRecurring.skip = function () {
   it.skip.apply(it, arguments)
 }
-
-export function expectedDate(startDate: DateTime, currentLocalDate: DateTime, targetZone: string): Date {
-  const targetOffset = startDate.setZone(targetZone).offset
-  const { zoneName: systemZone } = currentLocalDate
-  const {
-    offset: systemOffset,
-  } = startDate.setZone(systemZone)
-
-  const netOffset = targetOffset - systemOffset
-  const hours = -((netOffset / 60) % 24)
-  const minutes = -(netOffset % 60)
-  return startDate.plus({ hours, minutes }).toJSDate()
-}

--- a/test/rrule.test.ts
+++ b/test/rrule.test.ts
@@ -1,4 +1,4 @@
-import { parse, datetime, testRecurring, expectedDate } from './lib/utils'
+import { parse, datetime, testRecurring } from './lib/utils'
 import { expect } from 'chai'
 import { RRule, rrulestr, Frequency } from '../src/index'
 import { DateTime } from 'luxon'
@@ -3664,11 +3664,10 @@ describe('RRule', function () {
         tzid: targetZone
       })
       const recurrence = rule.all()[0]
-      const expected = expectedDate(startDate, currentLocalDate, targetZone)
 
       expect(recurrence)
         .to.deep.equal(
-          expected 
+          startDate.toJSDate()
         )
 
       resetMockDate()
@@ -3684,11 +3683,10 @@ describe('RRule', function () {
         tzid: targetZone
       })
       const recurrence = rule.all()[0]
-      const expected = expectedDate(startDate, currentLocalDate, targetZone)
 
       expect(recurrence)
         .to.deep.equal(
-          expected 
+          startDate.toJSDate()
         )
 
       resetMockDate()
@@ -3704,11 +3702,10 @@ describe('RRule', function () {
         tzid: targetZone
       })
       const recurrence = rule.after(new Date(0))
-      const expected = expectedDate(startDate, currentLocalDate, targetZone)
 
       expect(recurrence)
         .to.deep.equal(
-          expected 
+          startDate.toJSDate()
         )
 
       resetMockDate()

--- a/test/rruleset.test.ts
+++ b/test/rruleset.test.ts
@@ -1,4 +1,4 @@
-import { parse, datetime, testRecurring, expectedDate } from './lib/utils'
+import { parse, datetime, testRecurring } from './lib/utils'
 import { RRule, RRuleSet, rrulestr, Frequency } from '../src'
 import { DateTime } from 'luxon'
 import { expect } from 'chai'
@@ -533,10 +533,10 @@ describe('RRuleSet', function () {
       )     
 
       expect(set.all()).to.deep.equal([
-        expectedDate(DateTime.fromISO('20000101T090000'), currentLocalDate, targetZone),
-        expectedDate(DateTime.fromISO('20020101T090000'), currentLocalDate, targetZone),
-        expectedDate(DateTime.fromISO('20020301T090000'), currentLocalDate, targetZone),
-        expectedDate(DateTime.fromISO('20030101T090000'), currentLocalDate, targetZone),
+        DateTime.fromISO('20000101T090000').toJSDate(),
+        DateTime.fromISO('20020101T090000').toJSDate(),
+        DateTime.fromISO('20020301T090000').toJSDate(),
+        DateTime.fromISO('20030101T090000').toJSDate(),
       ])
 
       resetMockDate()
@@ -568,7 +568,7 @@ describe('RRuleSet', function () {
       )
 
       expect(set.all()).to.deep.equal([
-        expectedDate(DateTime.fromISO('20020301T090000'), currentLocalDate, targetZone)
+        DateTime.fromISO('20020301T090000').toJSDate()
       ])
 
       resetMockDate()


### PR DESCRIPTION
This bugfix addresses the bugs raised by the following issues, removing the additional offset applied by 'rezoning' that would see non-UTC times have their offset applied twice instead of once:

https://github.com/jakubroztocil/rrule/issues/355
https://github.com/jakubroztocil/rrule/issues/356

Since JavaScript `Date` objects track time via elapsed time since 00:00:00 Coordinated Universal Time (UTC), Thursday, 1 January 1970, applying an additional offset (i.e. 'rezoning') these dates should not be necessary as long as the `Date` was instantiated correctly.