### PR TITLE
Expose rrule exports to window so they can be used in the browser debugger

### DIFF
--- a/demo/demo.ts
+++ b/demo/demo.ts
@@ -1,9 +1,11 @@
 import * as $ from 'jquery'
-import {
-  RRule,
-  Options,
-  Weekday
-} from '../src/index'
+
+import { RRule, Weekday, Options } from '../src/index'
+
+// Make library accessible to browser debuggers so users can try things out themselves
+// tslint:disable-next-line:no-duplicate-imports
+import * as rruleExports from '../src/index'
+$.extend(window, rruleExports)
 
 const getDay = (i: number) => [
   RRule.MO,

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,19 +16,15 @@
 
 import RRule from './rrule'
 import RRuleSet from './rruleset'
-import { rrulestr } from './rrulestr'
+
+export { rrulestr } from './rrulestr'
 export { Frequency, ByWeekday, Options } from './types'
 export { Weekday, WeekdayStr } from './weekday'
 export { RRuleStrOptions } from './rrulestr'
 
-// =============================================================================
-// Export
-// =============================================================================
-
 export {
   RRule,
-  RRuleSet,
-  rrulestr
+  RRuleSet
 }
 
 export default RRule


### PR DESCRIPTION
Addresses: https://github.com/jakubroztocil/rrule/issues/365

Didn't write tests as this was for the demo app, and isn't really changing the functionality, can if needed though.