### PR TITLE
Drop old Node support

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [6.x, 8.x, 10.x, 12.x]
+        node-version: [10.x, 12.x]
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1


### PR DESCRIPTION
The current package.json doesn't build against older versions of Node. Given that Node 6 and 8 have been dropped from official "Current" support, I'm not sure it makes sense to continue supporting them here. In any event, we shouldn't need to fully build RRule against outdated Nodes in order to maintain compatibility with them.

---

### Thanks for contributing to `rrule`!

To submit a pull request, please verify that you have done the following:

- [ ] Merged in or rebased on the latest `master` commit
- [ ] Linked to an existing bug or issue describing the bug or feature you're
      addressing
- [ ] Written one or more tests showing that your change works as advertised
