### PR TITLE
Add support for byhour and byminute (HH:MM) text parsing for daily

### DIFF
--- a/src/nlp/i18n.ts
+++ b/src/nlp/i18n.ts
@@ -23,6 +23,7 @@ const ENGLISH: Language = {
   tokens: {
     'SKIP': /^[ \r\n\t]+|^\.$/,
     'number': /^[1-9][0-9]*/,
+    'hourMinuteTime': /^(2[0-3]|[01]?\d)(?::([0-5]\d))?/,
     'numberAsText': /^(one|two|three)/i,
     'every': /^every/i,
     'day(s)': /^days?/i,

--- a/src/nlp/totext.ts
+++ b/src/nlp/totext.ts
@@ -223,6 +223,8 @@ export default class ToText {
       this._bymonthday()
     } else if (this.byweekday) {
       this._byweekday()
+    } else if (this.origOptions.byhour && this.origOptions.byminute) {
+      this._byhourandminute()
     } else if (this.origOptions.byhour) {
       this._byhour()
     }
@@ -378,6 +380,36 @@ export default class ToText {
     )
   }
 
+  private _byhourandminute () {
+    const gettext = this.gettext
+    const { byhour, byminute } = this.origOptions
+
+    let byhourArray: number[] = []
+    let byminuteArray: number[] = []
+
+    if (Array.isArray(byhour)) {
+      byhourArray = byhour
+    } else if (byhour !== null && byhour !== undefined) {
+      byhourArray = [byhour]
+    }
+
+    if (Array.isArray(byminute)) {
+      byminuteArray = byminute
+    } else if (byminute !== null && byminute !== undefined) {
+      byminuteArray = [byminute]
+    }
+
+    if (byhourArray.length > 0 && byminuteArray.length > 0) {
+      const listOfTimes = byhourArray.reduce<string[]>((acc, hour) => {
+        return acc.concat(byminuteArray.map((minute) => `${hour}:${String(minute).padStart(2, '0')}`))
+      }, [])
+
+      this.add(gettext('at')).add(
+        this.list(listOfTimes, undefined, gettext('and'))
+      )
+    }
+  }
+
   private _bymonth () {
     this.add(
       this.list(this.options.bymonth!, this.monthtext, this.gettext('and'))
@@ -436,7 +468,7 @@ export default class ToText {
     return this
   }
 
-  list (arr: ByWeekday | ByWeekday[], callback?: GetText, finalDelim?: string, delim: string = ',') {
+  list (arr: ByWeekday | Array<ByWeekday | string>, callback?: GetText, finalDelim?: string, delim: string = ',') {
     if (!isArray(arr)) {
       arr = [arr]
     }
@@ -466,7 +498,7 @@ export default class ToText {
         return o.toString()
       }
     const self = this
-    const realCallback = function (arg: ByWeekday) {
+    const realCallback = function (arg: ByWeekday | string) {
       return callback && callback.call(self, arg)
     }
 

--- a/test/nlp.test.ts
+++ b/test/nlp.test.ts
@@ -26,7 +26,11 @@ const texts = [
   ['Every month on the last Monday', 'RRULE:FREQ=MONTHLY;BYDAY=-1MO'],
   ['Every month on the 2nd last Friday', 'RRULE:FREQ=MONTHLY;BYDAY=-2FR'],
   // ['Every week until January 1, 2007', 'RRULE:FREQ=WEEKLY;UNTIL=20070101T080000Z'],
-  ['Every week for 20 times', 'RRULE:FREQ=WEEKLY;COUNT=20']
+  ['Every week for 20 times', 'RRULE:FREQ=WEEKLY;COUNT=20'],
+  ['Every day at 9:10', 'RRULE:FREQ=DAILY;BYHOUR=9;BYMINUTE=10'],
+  ['Every day at 9', 'RRULE:FREQ=DAILY;BYHOUR=9'],
+  ['Every day at 23:10', 'RRULE:FREQ=DAILY;BYHOUR=23;BYMINUTE=10'],
+  ['Every day at 23:00, 23:30, 9:00 and 9:30', 'RRULE:FREQ=DAILY;BYHOUR=23,9;BYMINUTE=0,30'],
 ]
 
 describe('NLP', () => {


### PR DESCRIPTION
Added functionality:
* Support `at HH:MM` where minutes are optional for the daily case

```
'Every day at 9:10' =>  'RRULE:FREQ=DAILY;BYHOUR=9;BYMINUTE=10'
'Every day at 23:00, 23:30, 9:00 and 9:30' =>  'RRULE:FREQ=DAILY;BYHOUR=23,9;BYMINUTE=0,30'
```


This partially solves https://github.com/jakubroztocil/rrule/issues/387. While this issue is primarily about the monthly & weekly cases the same issue persists with the daily case.

I plan on having a subsequent PR that will make this applicable for byweekly and monthly assuming the minute parsing is accepted.|

---

### Thanks for contributing to `rrule`!

To submit a pull request, please verify that you have done the following:

- [X] Merged in or rebased on the latest `master` commit
- [X] Linked to an existing bug or issue describing the bug or feature you're
      addressing
- [X] Written one or more tests showing that your change works as advertised
