### PR TITLE
Fixed bug in  README's example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ rruleSet.rdate(new Date(Date.UTC(2012, 6, 1, 10, 30)))
 rruleSet.rdate(new Date(Date.UTC(2012, 6, 2, 10, 30)))
 
 // Add a exclusion rrule to rruleSet
-rruleSet.exrule(new r.RRule({
+rruleSet.exrule(new RRule({
   freq: RRule.MONTHLY,
   count: 2,
   dtstart: new Date(Date.UTC(2012, 2, 1, 10, 30))


### PR DESCRIPTION
Removed the additional "r." causes example code to fail.  
There are no issues raised about this. But the example code fails by just copy and pasting it to run.
---

### Thanks for contributing to `rrule`!

To submit a pull request, please verify that you have done the following:

- [x] Merged in or rebased on the latest `master` commit
- [ ] Linked to an existing bug or issue describing the bug or feature you're
      addressing
- [ ] Written one or more tests showing that your change works as advertised
