### PR TITLE
Luxonless binary should not contain any luxon imports.

### DIFF
--- a/src/fake-luxon.ts
+++ b/src/fake-luxon.ts
@@ -1,0 +1,5 @@
+export const DateTime = {
+  fromJSDate() {
+    throw new TypeError();
+  }
+};

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -54,9 +54,9 @@ const rruleConfig = Object.assign({
     rrule: path.join(paths.source, "index.ts"),
     'rrule.min': path.join(paths.source, "index.ts")
   },
-  externals: {
-    luxon: 'luxon'
-  },
+  plugins: [
+    new webpack.NormalModuleReplacementPlugin(/^luxon$/, './fake-luxon.ts'),
+  ]
 }, commonConfig);
 
 const rruleWithLuxonConfig = Object.assign({


### PR DESCRIPTION
**summary**
Fixes https://github.com/jakubroztocil/rrule/issues/344, and maybe https://github.com/jakubroztocil/rrule/issues/402.

Currently the build produced without timezone support still references `luxon` and expects the code to throw a `TypeError` if incorrectly used (done via webpack externals). You can verify this by searching for "luxon" within the contents of `dist/es5/rrule.min.js`.

This causes issue when mixed with compilers that don't have the same notion of an external, e.g. Closure Compiler (https://github.com/google/closure-compiler/issues/954). Specifically, the AMP Project is running into when trying to build rrule into our `amp-date-picker` component (https://github.com/ampproject/amphtml/pull/28887).

This PR uses [NormalModuleReplacementPlugin](https://webpack.js.org/plugins/normal-module-replacement-plugin/) to replace luxon with a fake implementation that immediately throws.