### PR TITLE
fix: typo plural minutes

### DIFF
--- a/src/nlp/totext.ts
+++ b/src/nlp/totext.ts
@@ -192,7 +192,7 @@ export default class ToText {
     this.add(
       this.plural(this.options.interval!)
         ? gettext('minutes')
-        : gettext('minutes')
+        : gettext('minute')
     )
   }
 

--- a/test/nlp.test.ts
+++ b/test/nlp.test.ts
@@ -79,6 +79,18 @@ describe('NLP', () => {
     expect(rule.toText()).to.equal('every day')
   })
 
+  it('shows correct text for every minute', () => {
+    const options = { 'freq': RRule.MINUTELY };
+    const rule = new RRule(options);
+    expect(rule.toText()).to.equal('every minute');
+  });
+
+  it('shows correct text for every (plural) minutes', () => {
+    const options = { 'freq': RRule.MINUTELY, 'interval': 2 };
+    const rule = new RRule(options);
+    expect(rule.toText()).to.equal('every 2 minutes');
+  });
+
   it('by default formats \'until\' correctly', () => {
     const rrule = new RRule({
       freq: RRule.WEEKLY,


### PR DESCRIPTION
Fixed typo and added tests for single and plural.

https://github.com/jakubroztocil/rrule/issues/406

---

### Thanks for contributing to `rrule`!

To submit a pull request, please verify that you have done the following:

- [x] Merged in or rebased on the latest `master` commit
- [x] Linked to an existing bug or issue describing the bug or feature you're
      addressing
- [x] Written one or more tests showing that your change works as advertised
