### PR TITLE
Add isFinite, first & last to rrule & rruleset

### DIFF
--- a/src/parseoptions.ts
+++ b/src/parseoptions.ts
@@ -33,6 +33,15 @@ export function parseOptions (options: Partial<Options>) {
 
   if (!opts.dtstart) opts.dtstart = new Date(new Date().setMilliseconds(0))
 
+  // infinite count is handled by null
+  if (isNumber(opts.count)) {
+    if (opts.count === Number.POSITIVE_INFINITY) {
+      opts.count = null
+    } else if (!Number.isSafeInteger(opts.count)) {
+      throw new Error('Invalid option: Count can only be a safe integer, null, or positive infinity')
+    }
+  }
+
   if (!isPresent(opts.wkst)) {
     opts.wkst = RRule.MO.weekday
   } else if (isNumber(opts.wkst)) {

--- a/src/rrule.ts
+++ b/src/rrule.ts
@@ -235,6 +235,40 @@ export default class RRule implements QueryMethods {
   }
 
   /**
+   * Returns the very first occurrence of this rrule if it exists, null otherwise
+   *
+   * @returns {Date | null}
+   */
+  first (): Date | null {
+    return this.after(this.options.dtstart, true) || null
+  }
+
+  /**
+   * Returns the last occurrence of this rrule if it exists, null otherwise
+   * @returns {Date | null}
+   */
+  last (): Date | null {
+    if (!this.isFinite()) {
+      return null
+    }
+
+    if (this.options.until) {
+      return this.before(this.options.until, true)
+    }
+
+    const allDates = this.all()
+    return allDates[allDates.length - 1] || null
+  }
+
+  /**
+   * Returns whether the number of recurrence in this set is finite.
+   * @returns {boolean}
+   */
+  isFinite (): boolean {
+    return this.options.until != null || this.options.count != null || this.options.interval === 0
+  }
+
+  /**
    * Returns the number of recurrences in this set. It will have go trough
    * the whole recurrence, if this hasn't been done before.
    */

--- a/src/rrule.ts
+++ b/src/rrule.ts
@@ -158,6 +158,10 @@ export default class RRule implements QueryMethods {
       return this._iter(new CallbackIterResult('all', {}, iterator))
     }
 
+    if (!this.isFinite()) {
+      throw new Error('Calling RRule.all() without an iterator on this RRule would result in an infinite loop as its recurrence set is not finite')
+    }
+
     let result = this._cacheGet('all') as Date[] | false
     if (result === false) {
       result = this._iter(new IterResult('all', {}))
@@ -271,8 +275,14 @@ export default class RRule implements QueryMethods {
   /**
    * Returns the number of recurrences in this set. It will have go trough
    * the whole recurrence, if this hasn't been done before.
+   *
+   * If the number of recurrence in this set is infinite, Positive infinity will be returned.
    */
   count (): number {
+    if (!this.isFinite()) {
+      return Number.POSITIVE_INFINITY
+    }
+
     return this.all().length
   }
 

--- a/src/rruleset.ts
+++ b/src/rruleset.ts
@@ -136,6 +136,59 @@ export default class RRuleSet extends RRule {
     return this._exdate.map(e => new Date(e.getTime()))
   }
 
+  /**
+   * Returns the very first occurrence of this rrule set if it exists, null otherwise
+   *
+   * @returns {Date | null}
+   */
+  first (): Date | null {
+    let earliestDate = null
+    for (const rrule of this._rrule) {
+      if (!earliestDate || rrule.options.dtstart < earliestDate) {
+        earliestDate = rrule.options.dtstart
+      }
+    }
+
+    for (const rdate of this._rdate) {
+      if (!earliestDate || rdate < earliestDate) {
+        earliestDate = rdate
+      }
+    }
+
+    if (earliestDate == null) {
+      return null
+    }
+
+    return this.after(earliestDate, true)
+  }
+
+  /**
+   * Returns the last occurrence of this rrule set if it exists, null otherwise
+   * @returns {Date | null}
+   */
+  last (): Date | null {
+    if (!this.isFinite()) {
+      return null
+    }
+
+    const allDates = this.all()
+    return allDates[allDates.length - 1] || null
+  }
+
+  /**
+   * Returns whether the number of recurrence in this set is finite.
+   * @returns {boolean}
+   */
+  isFinite (): boolean {
+    for (const rrule of this._rrule) {
+      if (!rrule.isFinite()) {
+        return false
+      }
+    }
+
+    return true
+  }
+
   valueOf () {
     let result: string[] = []
 

--- a/test/lib/utils.ts
+++ b/test/lib/utils.ts
@@ -17,8 +17,8 @@ const assertDatesEqual = function (actual: Date | Date[], expected: Date | Date[
   for (let i = 0; i < expected.length; i++) {
     const act = actual[i]
     const exp = expected[i]
-    expect(exp instanceof Date ? exp.toString() : exp).to.equal(
-      act.toString(), msg + (i + 1) + '/' + expected.length)
+    expect(act.toString()).to.equal(
+      exp instanceof Date ? exp.toString() : exp, msg + (i + 1) + '/' + expected.length)
   }
 }
 

--- a/test/rrule.test.ts
+++ b/test/rrule.test.ts
@@ -35,7 +35,10 @@ describe('RRule', function () {
     'FREQ=HOURLY;INTERVAL=0;BYSETPOS=1;BYDAY=MO',
     'FREQ=MINUTELY;INTERVAL=0;BYSETPOS=1;BYDAY=MO',
     'FREQ=SECONDLY;INTERVAL=0;BYSETPOS=1;BYDAY=MO']
-    .map((s) => expect(rrulestr(s).count()).to.equal(0))
+    .map((s) => {
+      expect(rrulestr(s).count()).to.equal(0);
+      expect(rrulestr(s).isFinite()).to.equal(true);
+    })
   })
 
   it('does not mutate the passed-in options object', function () {
@@ -155,6 +158,76 @@ describe('RRule', function () {
       datetime(1997, 9, 6, 9, 0)
     ]
   )
+
+  testRecurring('testFirst',
+    {
+      rrule: new RRule({
+        freq: RRule.DAILY,
+        dtstart: parse('19970902T090000')
+      }),
+      method: 'first'
+    },
+    [
+      datetime(1997, 9, 2, 9, 0)
+    ]
+  )
+
+  it('testLastZeroInterval', () => {
+    const rrule = new RRule({
+      freq: RRule.DAILY,
+      dtstart: parse('19970902T090000'),
+      interval: 0
+    })
+
+    expect(rrule.first()).to.equal(null)
+  })
+
+  testRecurring('testLastFiniteCount',
+    {
+      rrule: new RRule({
+        freq: RRule.DAILY,
+        dtstart: parse('19970902T090000'),
+        count: 4
+      }),
+      method: 'last'
+    },
+    [
+      datetime(1997, 9, 5, 9, 0)
+    ]
+  )
+
+  testRecurring('testLastFiniteUntil',
+    {
+      rrule: new RRule({
+        freq: RRule.DAILY,
+        dtstart: parse('19970902T090000'),
+        until: parse('19970910T090000')
+      }),
+      method: 'last'
+    },
+    [
+      datetime(1997, 9, 10, 9, 0)
+    ]
+  )
+
+  it('testLastInfinite', () => {
+    const rrule = new RRule({
+      freq: RRule.DAILY,
+      dtstart: parse('19970902T090000')
+    })
+
+    expect(rrule.last()).to.equal(null)
+  })
+
+  it('testLastZeroInterval', () => {
+    const rrule = new RRule({
+      freq: RRule.DAILY,
+      dtstart: parse('19970902T090000'),
+      interval: 0
+    })
+
+    expect(rrule.last()).to.equal(null)
+  })
 
   testRecurring('testYearly',
     new RRule({

--- a/test/rruleset.test.ts
+++ b/test/rruleset.test.ts
@@ -575,6 +575,237 @@ describe('RRuleSet', function () {
     })
   })
 
+  describe('first', () => {
+    testRecurring('with simple rrule',
+      () => {
+        const set = new RRuleSet()
+
+        set.rrule(new RRule({
+          freq: RRule.DAILY,
+          count: 2,
+          dtstart: parse('20200928T090000')
+        }))
+
+        return {
+          rrule: set,
+          method: 'first'
+        }
+      },
+      datetime(2020, 9, 28, 9, 0)
+    )
+
+    testRecurring('with simple rrule and rdate',
+      () => {
+        const set = new RRuleSet()
+
+        set.rrule(new RRule({
+          freq: RRule.DAILY,
+          count: 2,
+          dtstart: parse('20200928T090000')
+        }))
+
+        set.rdate(datetime(2020, 9, 26, 9, 0))
+
+        return {
+          rrule: set,
+          method: 'first'
+        }
+      },
+      datetime(2020, 9, 26, 9, 0)
+    )
+
+    testRecurring('with simple rrule and exdate',
+      () => {
+        const set = new RRuleSet()
+
+        set.rrule(new RRule({
+          freq: RRule.DAILY,
+          count: 2,
+          dtstart: parse('20200928T090000')
+        }))
+
+        set.exdate(datetime(2020, 9, 28, 9, 0))
+
+        return {
+          rrule: set,
+          method: 'first'
+        }
+      },
+      datetime(2020, 9, 29, 9, 0)
+    )
+
+    testRecurring('with simple rrule and exrule',
+      () => {
+        const set = new RRuleSet()
+
+        set.rrule(new RRule({
+          freq: RRule.DAILY,
+          count: 2,
+          dtstart: parse('20200928T090000')
+        }))
+
+        set.exrule(new RRule({
+          freq: RRule.DAILY,
+          count: 2,
+          dtstart: parse('20200927T090000')
+        }))
+
+        return {
+          rrule: set,
+          method: 'first'
+        }
+      },
+      datetime(2020, 9, 29, 9, 0)
+    )
+
+    it('returns null if empty', () => {
+      const set = new RRuleSet()
+      expect(set.first()).to.equal(null)
+    })
+
+    it('returns null if rules exclude each-other', () => {
+      const set = new RRuleSet()
+
+      set.rrule(new RRule({
+        freq: RRule.DAILY,
+        count: 2,
+        dtstart: parse('20200928T090000')
+      }))
+
+      set.exrule(new RRule({
+        freq: RRule.DAILY,
+        count: 2,
+        dtstart: parse('20200928T090000')
+      }))
+
+      expect(set.first()).to.equal(null)
+    })
+  })
+
+  describe('last', () => {
+    testRecurring('with simple rrule',
+      () => {
+        const set = new RRuleSet()
+
+        set.rrule(new RRule({
+          freq: RRule.DAILY,
+          count: 2,
+          dtstart: parse('20200928T090000')
+        }))
+
+        return {
+          rrule: set,
+          method: 'last'
+        }
+      },
+      datetime(2020, 9, 29, 9, 0)
+    )
+
+    testRecurring('with simple rrule and rdate',
+      () => {
+        const set = new RRuleSet()
+
+        set.rrule(new RRule({
+          freq: RRule.DAILY,
+          count: 2,
+          dtstart: parse('20200928T090000')
+        }))
+
+        set.rdate(datetime(2021, 9, 26, 9, 0))
+
+        return {
+          rrule: set,
+          method: 'last'
+        }
+      },
+      datetime(2021, 9, 26, 9, 0)
+    )
+
+    testRecurring('with simple rrule and exdate',
+      () => {
+        const set = new RRuleSet()
+
+        set.rrule(new RRule({
+          freq: RRule.DAILY,
+          count: 3,
+          dtstart: parse('20200928T090000')
+        }))
+
+        set.exdate(datetime(2020, 9, 30, 9, 0))
+
+        return {
+          rrule: set,
+          method: 'last'
+        }
+      },
+      datetime(2020, 9, 29, 9, 0)
+    )
+
+    testRecurring('with simple rrule and exrule',
+      () => {
+        const set = new RRuleSet()
+
+        set.rrule(new RRule({
+          freq: RRule.DAILY,
+          count: 4,
+          dtstart: parse('20200927T090000')
+        }))
+
+        set.exrule(new RRule({
+          freq: RRule.DAILY,
+          count: 2,
+          dtstart: parse('20200929T090000')
+        }))
+
+        return {
+          rrule: set,
+          method: 'last'
+        }
+      },
+      datetime(2020, 9, 28, 9, 0)
+    )
+
+    it('returns null if infinite', () => {
+      const set = new RRuleSet()
+
+      set.rrule(new RRule({
+        freq: RRule.DAILY,
+        count: 2,
+        dtstart: parse('20200928T090000')
+      }))
+
+      set.rrule(new RRule({
+        freq: RRule.DAILY,
+        dtstart: parse('20200928T090000')
+      }))
+
+      expect(set.last()).to.equal(null)
+    })
+
+    it('returns null if empty', () => {
+      const set = new RRuleSet()
+      expect(set.last()).to.equal(null)
+    })
+
+    it('returns null if rules exclude each-other', () => {
+      const set = new RRuleSet()
+
+      set.rrule(new RRule({
+        freq: RRule.DAILY,
+        count: 2,
+        dtstart: parse('20200928T090000')
+      }))
+
+      set.exrule(new RRule({
+        freq: RRule.DAILY,
+        count: 2,
+        dtstart: parse('20200928T090000')
+      }))
+
+      expect(set.last()).to.equal(null)
+    })
+  })
+
   describe('with end date', () => {
     let cursor: DateTime
 


### PR DESCRIPTION
This implements feature request https://github.com/jakubroztocil/rrule/issues/215

- `isFinite` returns true if the rrule/rruleset has a determinable final occurrence
- `last` returns the final occurrence if it exists and is determinable
- `first` returns the first occurrence if it exists

This PR also implements the following revertible changes:

- calling `count` on an infinite rrule/rruleset now returns `Number.POSITIVE_INFINITY` instead of returning all possible dates until the year 9999 - could be considered breaking.
- calling `all` on an infinite rrule/rruleset now throws instead of returning all dates until the year 9999 (unless an iterator has been provided as the iterator can stop the loop) - could be considered breaking.
- `options.count` throws if it received something other than a safe integer, `null` or `Number.POSITIVE_INFINITY`. `Number.POSITIVE_INFINITY` normalizes to `null`.

---

### Thanks for contributing to `rrule`!

To submit a pull request, please verify that you have done the following:

- [x] Merged in or rebased on the latest `master` commit
- [x] Linked to an existing bug or issue describing the bug or feature you're
      addressing
- [x] Written one or more tests showing that your change works as advertised
