### PR TITLE
Solving circular import hack

### DIFF
--- a/src/nlp/index.ts
+++ b/src/nlp/index.ts
@@ -1,6 +1,7 @@
 import ToText, { DateFormatter, GetText } from './totext'
 import parseText from './parsetext'
 import RRule from '../index'
+import { Frequency } from '../types'
 import ENGLISH, { Language } from './i18n'
 
 /*!
@@ -108,12 +109,12 @@ const common = [
 ]
 
 ToText.IMPLEMENTED = []
-ToText.IMPLEMENTED[RRule.HOURLY] = common
-ToText.IMPLEMENTED[RRule.MINUTELY] = common
-ToText.IMPLEMENTED[RRule.DAILY] = ['byhour'].concat(common)
-ToText.IMPLEMENTED[RRule.WEEKLY] = common
-ToText.IMPLEMENTED[RRule.MONTHLY] = common
-ToText.IMPLEMENTED[RRule.YEARLY] = ['byweekno', 'byyearday'].concat(common)
+ToText.IMPLEMENTED[Frequency.HOURLY] = common
+ToText.IMPLEMENTED[Frequency.MINUTELY] = common
+ToText.IMPLEMENTED[Frequency.DAILY] = ['byhour'].concat(common)
+ToText.IMPLEMENTED[Frequency.WEEKLY] = common
+ToText.IMPLEMENTED[Frequency.MONTHLY] = common
+ToText.IMPLEMENTED[Frequency.YEARLY] = ['byweekno', 'byyearday'].concat(common)
 
 // =============================================================================
 // Export

--- a/src/rrule.ts
+++ b/src/rrule.ts
@@ -3,7 +3,7 @@ import dateutil from './dateutil'
 import IterResult, { IterArgs } from './iterresult'
 import CallbackIterResult from './callbackiterresult'
 import { Language } from './nlp/i18n'
-import { Nlp } from './nlp/index'
+import { fromText, parseText, toText, isFullyConvertible } from './nlp/index'
 import { DateFormatter, GetText } from './nlp/totext'
 import { ParsedOptions, Options, Frequency, QueryMethods, QueryMethodTypes, IterResultType } from './types'
 import { parseOptions, initializeOptions } from './parseoptions'
@@ -12,19 +12,6 @@ import { optionsToString } from './optionstostring'
 import { Cache, CacheKeys } from './cache'
 import { Weekday } from './weekday'
 import { iter } from './iter/index'
-
-interface GetNlp {
-  _nlp: Nlp
-  (): Nlp
-}
-
-const getnlp: GetNlp = function () {
-  // Lazy, runtime import to avoid circular refs.
-  if (!getnlp._nlp) {
-    getnlp._nlp = require('./nlp')
-  }
-  return getnlp._nlp
-} as GetNlp
 
 // =============================================================================
 // RRule
@@ -114,11 +101,11 @@ export default class RRule implements QueryMethods {
   }
 
   static parseText (text: string, language?: Language) {
-    return getnlp().parseText(text, language)
+    return parseText(text, language)
   }
 
   static fromText (text: string, language?: Language) {
-    return getnlp().fromText(text, language)
+    return fromText(text, language)
   }
 
   static parseString = parseString
@@ -256,11 +243,11 @@ export default class RRule implements QueryMethods {
    * to text.
    */
   toText (gettext?: GetText, language?: Language, dateFormatter?: DateFormatter) {
-    return getnlp().toText(this, gettext, language, dateFormatter)
+    return toText(this, gettext, language, dateFormatter)
   }
 
   isFullyConvertibleToText () {
-    return getnlp().isFullyConvertible(this)
+    return isFullyConvertible(this)
   }
 
   /**


### PR DESCRIPTION
These fixes should prevent problems with circular imports. I still get 14 warnings about circular imports in rollup (regardless of using the main commonjs plugin or the alternate one), but at least the emitted code seems to work fine in both now.

This fixes #443 and hopefully #430, although I haven't been able to reproduce the issue in webpack.

I also looked into extracting other circular usages (like `totext.ts` accessing `RRule.FREQUENCIES`), but that quickly produced quite a lot of changes. I can continue trying to weed out the rest of the circular import warnings if you want, just let me know. 

---

### Thanks for contributing to `rrule`!

To submit a pull request, please verify that you have done the following:

- [Y] Merged in or rebased on the latest `master` commit
- [Y] Linked to an existing bug or issue describing the bug or feature you're
      addressing
- [N] Written one or more tests showing that your change works as advertised
