### PR TITLE
Fix incorrect source paths in generated source maps (#303)

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "baseUrl": "./dist/esm",
     "outDir": "./dist/esm",
     "declaration": true,
     "declarationMap": true,


### PR DESCRIPTION
Fixes the incorrect source paths in generated source maps, which was reported in https://github.com/jakubroztocil/rrule/issues/303 but never fixed.

The issue can be reproduced using @anthwinter's [original repro](https://github.com/jakubroztocil/rrule/issues/303#issuecomment-444019370).

---

### Thanks for contributing to `rrule`!

To submit a pull request, please verify that you have done the following:

- [x] Merged in or rebased on the latest `master` commit
- [x] Linked to an existing bug or issue describing the bug or feature you're
      addressing
- [ ] Written one or more tests showing that your change works as advertised
