### PR TITLE
fix: resolve circular import

### DIFF
--- a/src/nlp/index.ts
+++ b/src/nlp/index.ts
@@ -1,6 +1,6 @@
 import ToText, { DateFormatter, GetText } from './totext'
 import parseText from './parsetext'
-import RRule from '../index'
+import RRule from '../rrule'
 import { Frequency } from '../types'
 import ENGLISH, { Language } from './i18n'
 

--- a/src/nlp/parsetext.ts
+++ b/src/nlp/parsetext.ts
@@ -1,5 +1,5 @@
 import ENGLISH, { Language } from './i18n'
-import RRule from '../index'
+import RRule from '../rrule'
 import { Options } from '../types'
 import { WeekdayStr } from '../weekday'
 

--- a/src/nlp/totext.ts
+++ b/src/nlp/totext.ts
@@ -1,8 +1,8 @@
 import ENGLISH, { Language } from './i18n'
-import RRule from '../index'
+import RRule from '../rrule'
 import { Options, ByWeekday } from '../types'
 import { Weekday } from '../weekday'
-import { isArray, isNumber, isPresent, padStart } from '../helpers'
+import { isArray, isNumber, isPresent } from '../helpers'
 
 // =============================================================================
 // Helper functions


### PR DESCRIPTION
The RRule in rrulset.ts ends up being undefined because the root index is being
loaded while files such as nlp/totext.ts depend on the root index while
rrule.ts depends on nlp/index.ts. Then, at one point the execution
proceeds even though the root index has not fully loaded.

---

### Thanks for contributing to `rrule`!

To submit a pull request, please verify that you have done the following:

- [x] Merged in or rebased on the latest `master` commit
- [ ] Linked to an existing bug or issue describing the bug or feature you're
      addressing
- [ ] Written one or more tests showing that your change works as advertised
