### PR TITLE
fix(cache): cache key comparison ignores milliseconds

### DIFF
--- a/src/cache.ts
+++ b/src/cache.ts
@@ -4,6 +4,24 @@ import { isArray } from './helpers'
 
 export type CacheKeys = 'before' | 'after' | 'between'
 
+function argsMatch (
+  left: IterArgs[keyof IterArgs] | undefined,
+  right: IterArgs[keyof IterArgs] | undefined
+) {
+  if (Array.isArray(left)) {
+    if (!Array.isArray(right)) return false
+    if (left.length !== right.length) return false
+    if (left.length === 0) return true
+    return left.every((date, i) => date.getTime() === right[i].getTime())
+  }
+
+  if (left instanceof Date) {
+    return right instanceof Date && left.getTime() === right.getTime()
+  }
+
+  return left === right
+}
+
 export class Cache {
   all: Date[] | Partial<IterArgs> | false = false
   before: IterArgs[] = []
@@ -51,7 +69,7 @@ export class Cache {
     const findCacheDiff = function (item: IterArgs) {
       for (let i = 0; i < argsKeys.length; i++) {
         const key = argsKeys[i]
-        if (String(args![key]) !== String(item[key])) {
+        if (!argsMatch(args![key], item[key])) {
           return true
         }
       }
@@ -89,5 +107,4 @@ export class Cache {
         ? dateutil.clone(cached)
         : cached
   }
-
 }

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -11,7 +11,6 @@ function argsMatch (
   if (Array.isArray(left)) {
     if (!Array.isArray(right)) return false
     if (left.length !== right.length) return false
-    if (left.length === 0) return true
     return left.every((date, i) => date.getTime() === right[i].getTime())
   }
 

--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -1,0 +1,101 @@
+import { Cache } from "../src/cache";
+import { expect } from "chai";
+import { IterArgs } from "../src/iterresult";
+
+const dates = [
+  new Date("2021-01-01T00:00:00.000+00:00"),
+  new Date("2021-01-02T00:00:00.000+00:00"),
+  new Date("2021-01-03T00:00:00.000+00:00"),
+  new Date("2021-01-04T00:00:00.000+00:00"),
+  new Date("2021-01-05T00:00:00.000+00:00"),
+  new Date("2021-01-06T00:00:00.000+00:00"),
+  new Date("2021-01-07T00:00:00.000+00:00"),
+];
+
+describe("Cache", () => {
+  it("returns false for an empty cache", () => {
+    const cache = new Cache();
+    const args: Partial<IterArgs> = {
+      after: new Date("2021-01-01T00:00:00.000+00:00"),
+      before: new Date("2021-01-08T00:00:00.000+00:00"),
+      inc: true,
+    };
+
+    expect(cache._cacheGet("between", args)).to.be.false;
+  });
+
+  it("returns an empty array for a cached but empty set", () => {
+    const cache = new Cache();
+    const args: Partial<IterArgs> = {
+      after: new Date("2021-01-01T00:00:00.000+00:00"),
+      before: new Date("2021-01-08T00:00:00.000+00:00"),
+      inc: true,
+    };
+
+    cache._cacheAdd("between", [], args);
+
+    expect(cache._cacheGet("between", args)).to.eql([]);
+  });
+
+  it('returns cached entries if the "what" and the args both match', () => {
+    const cache = new Cache();
+    const args: Partial<IterArgs> = {
+      after: new Date("2021-01-01T00:00:00.000+00:00"),
+      before: new Date("2021-01-08T00:00:00.000+00:00"),
+      inc: true,
+    };
+
+    cache._cacheAdd("between", dates, args);
+
+    expect(cache._cacheGet("between", args)).to.eql(dates);
+  });
+
+  it('does not return cached entries if the "what" matches but the args do not', () => {
+    const cache = new Cache();
+    const args: Partial<IterArgs> = {
+      after: new Date("2021-01-01T00:00:00.000+00:00"),
+      before: new Date("2021-01-08T00:00:00.000+00:00"),
+      inc: true,
+    };
+
+    cache._cacheAdd("between", dates, args);
+
+    expect(
+      cache._cacheGet("between", {
+        ...args,
+        /** 1ms later than the args used for the insert */
+        after: new Date("2021-01-01T00:00:00.001+00:00"),
+      })
+    ).to.equal(false);
+  });
+
+  it('does not return cached entries if args match but the "what" does not', () => {
+    const cache = new Cache();
+    const args: Partial<IterArgs> = {
+      after: new Date("2021-01-01T00:00:00.000+00:00"),
+      before: new Date("2021-01-08T00:00:00.000+00:00"),
+      inc: true,
+    };
+
+    cache._cacheAdd("between", dates, args);
+
+    expect(cache._cacheGet("after", args)).to.equal(false);
+  });
+
+  it('reuses dates cached for the "all" method when querying using another method', () => {
+    const cache = new Cache();
+    const args: Partial<IterArgs> = {
+      after: new Date("2021-01-04T00:00:00.000+00:00"),
+      before: new Date("2021-01-06T00:00:00.000+00:00"),
+      inc: true,
+    };
+
+    cache._cacheAdd("all", dates);
+
+    expect(cache._cacheGet("between", args)).to.eql([
+      new Date("2021-01-04T00:00:00.000+00:00"),
+      new Date("2021-01-05T00:00:00.000+00:00"),
+      new Date("2021-01-06T00:00:00.000+00:00"),
+    ]);
+  });
+});


### PR DESCRIPTION
See #489. The comparison used for cache keys ignores milliseconds, leading to false positive cache hits.

In this PR I've changed the comparison strategy to compare the unix timestamps of the relevant dates instead. Let me know whether you think this is the right approach :) 

### Thanks for contributing to `rrule`!

To submit a pull request, please verify that you have done the following:

- [X] Merged in or rebased on the latest `master` commit
- [X] Linked to an existing bug or issue describing the bug or feature you're
      addressing
- [X] Written one or more tests showing that your change works as advertised
