### PR TITLE
fix: Allow silencing Luxon Unsupported Errors

### DIFF
--- a/src/datewithzone.ts
+++ b/src/datewithzone.ts
@@ -1,6 +1,6 @@
 import dateutil from './dateutil'
 import { DateTime } from 'luxon'
-import { RRuleErrorHandler } from './error'
+import RRuleError from './rruleerror'
 
 export class DateWithZone {
   public date: Date
@@ -42,7 +42,7 @@ export class DateWithZone {
       return rezoned.toJSDate()
     } catch (e) {
       if (e instanceof TypeError) {
-        RRuleErrorHandler.logLuxonTzidError(e)
+        RRuleError.logLuxonTzidError(e)
       }
       return this.date
     }

--- a/src/datewithzone.ts
+++ b/src/datewithzone.ts
@@ -1,20 +1,21 @@
 import dateutil from './dateutil'
 import { DateTime } from 'luxon'
+import { RRuleErrorHandler } from './error'
 
 export class DateWithZone {
   public date: Date
   public tzid?: string | null
 
-  constructor (date: Date, tzid?: string | null) {
+  constructor(date: Date, tzid?: string | null) {
     this.date = date
     this.tzid = tzid
   }
 
-  private get isUTC () {
+  private get isUTC() {
     return !this.tzid || this.tzid.toUpperCase() === 'UTC'
   }
 
-  public toString () {
+  public toString() {
     const datestr = dateutil.timeToUntilString(this.date.getTime(), this.isUTC)
     if (!this.isUTC) {
       return `;TZID=${this.tzid}:${datestr}`
@@ -23,11 +24,11 @@ export class DateWithZone {
     return `:${datestr}`
   }
 
-  public getTime () {
+  public getTime() {
     return this.date.getTime()
   }
 
-  public rezonedDate () {
+  public rezonedDate() {
     if (this.isUTC) {
       return this.date
     }
@@ -41,7 +42,7 @@ export class DateWithZone {
       return rezoned.toJSDate()
     } catch (e) {
       if (e instanceof TypeError) {
-        console.error('Using TZID without Luxon available is unsupported. Returned times are in UTC, not the requested time zone')
+        RRuleErrorHandler.logLuxonTzidError(e);
       }
       return this.date
     }

--- a/src/datewithzone.ts
+++ b/src/datewithzone.ts
@@ -6,16 +6,16 @@ export class DateWithZone {
   public date: Date
   public tzid?: string | null
 
-  constructor(date: Date, tzid?: string | null) {
+  constructor (date: Date, tzid?: string | null) {
     this.date = date
     this.tzid = tzid
   }
 
-  private get isUTC() {
+  private get isUTC () {
     return !this.tzid || this.tzid.toUpperCase() === 'UTC'
   }
 
-  public toString() {
+  public toString () {
     const datestr = dateutil.timeToUntilString(this.date.getTime(), this.isUTC)
     if (!this.isUTC) {
       return `;TZID=${this.tzid}:${datestr}`
@@ -24,11 +24,11 @@ export class DateWithZone {
     return `:${datestr}`
   }
 
-  public getTime() {
+  public getTime () {
     return this.date.getTime()
   }
 
-  public rezonedDate() {
+  public rezonedDate () {
     if (this.isUTC) {
       return this.date
     }
@@ -42,7 +42,7 @@ export class DateWithZone {
       return rezoned.toJSDate()
     } catch (e) {
       if (e instanceof TypeError) {
-        RRuleErrorHandler.logLuxonTzidError(e);
+        RRuleErrorHandler.logLuxonTzidError(e)
       }
       return this.date
     }

--- a/src/error.ts
+++ b/src/error.ts
@@ -1,0 +1,12 @@
+
+export class RRuleErrorHandler {
+
+  static emitLuxonTzidError = true;
+
+  static logLuxonTzidError(e: TypeError) {
+    if (this.emitLuxonTzidError) {
+      console.error('Using TZID without Luxon available is unsupported. Returned times are in UTC, not the requested time zone')
+    }
+  }
+
+}

--- a/src/error.ts
+++ b/src/error.ts
@@ -1,9 +1,9 @@
 
 export class RRuleErrorHandler {
 
-  static emitLuxonTzidError = true;
+  static emitLuxonTzidError = true
 
-  static logLuxonTzidError(e: TypeError) {
+  static logLuxonTzidError (e: TypeError) {
     if (this.emitLuxonTzidError) {
       console.error('Using TZID without Luxon available is unsupported. Returned times are in UTC, not the requested time zone')
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@
 
 import RRule from './rrule'
 import RRuleSet from './rruleset'
+import RRuleError from './rruleerror'
 
 export { rrulestr } from './rrulestr'
 export { Frequency, ByWeekday, Options } from './types'
@@ -24,7 +25,8 @@ export { RRuleStrOptions } from './rrulestr'
 
 export {
   RRule,
-  RRuleSet
+  RRuleSet,
+  RRuleError
 }
 
 export default RRule

--- a/src/rruleerror.ts
+++ b/src/rruleerror.ts
@@ -1,5 +1,5 @@
 
-export class RRuleErrorHandler {
+export default class RRuleError {
 
   static emitLuxonTzidError = true
 


### PR DESCRIPTION
Referenced in [#411](https://github.com/jakubroztocil/rrule/issues/441#issuecomment-876788917).

Moves the error call to a static class and allows it to be switched off globally.

---

### Thanks for contributing to `rrule`!

To submit a pull request, please verify that you have done the following:

- [x] Merged in or rebased on the latest `master` commit
- [x] Linked to an existing bug or issue describing the bug or feature you're
      addressing
- [ ] Written one or more tests showing that your change works as advertised
