### PR TITLE
fix: infinite loops in iter when interval is undefined

### DIFF
--- a/src/parseoptions.ts
+++ b/src/parseoptions.ts
@@ -27,6 +27,8 @@ export function parseOptions (options: Partial<Options>) {
 
   if (isPresent(opts.byeaster)) opts.freq = RRule.YEARLY
 
+  if (!isPresent(opts.interval)) opts.interval = 1
+
   if (!(isPresent(opts.freq) && RRule.FREQUENCIES[opts.freq])) {
     throw new Error(`Invalid frequency: ${opts.freq} ${options.freq}`)
   }

--- a/test/parseoptions.test.ts
+++ b/test/parseoptions.test.ts
@@ -46,3 +46,10 @@ describe('byweekday', () => {
     expect(options.parsedOptions.byweekday).to.eql([1, 2])
   })
 })
+
+describe('interval', () => {
+  it('assigns interval to 1 when not present', () => {
+    const options = parseOptions({interval: undefined})
+    expect(options.parsedOptions.interval).to.eql(1)
+  })
+})


### PR DESCRIPTION
This fixes the issue described in #481. 

The issue can be reproduced by create an rrule with an interval of undefined or null (overwriting the default 1), and then calling `after`, `between`, `before`

iCalendar RFC states that interval should be a positive integer, so this fix ensures that if not present interval is set back to the default of 1.

---

### Thanks for contributing to `rrule`!

To submit a pull request, please verify that you have done the following:

- [x] Merged in or rebased on the latest `master` commit
- [x] Linked to an existing bug or issue describing the bug or feature you're
      addressing
- [x] Written one or more tests showing that your change works as advertised
