### PR TITLE
Allow luxon alternatives to handle timezones 

### DIFF
--- a/src/datewithzone.ts
+++ b/src/datewithzone.ts
@@ -1,5 +1,6 @@
 import dateutil from './dateutil'
 import { DateTime } from 'luxon'
+import rrule from './rrule'
 
 export class DateWithZone {
   public date: Date
@@ -33,6 +34,10 @@ export class DateWithZone {
     }
 
     try {
+      if (rrule.customRezonedDate) {
+        return (rrule.customRezonedDate(this.date, this.tzid!))
+      }
+
       const datetime = DateTime
         .fromJSDate(this.date)
 

--- a/src/rrule.ts
+++ b/src/rrule.ts
@@ -100,6 +100,8 @@ export default class RRule implements QueryMethods {
     this.options = parsedOptions
   }
 
+  static customRezonedDate: (date: Date, timezone: String) => Date
+
   static parseText (text: string, language?: Language) {
     return parseText(text, language)
   }

--- a/test/datewithzone.test.ts
+++ b/test/datewithzone.test.ts
@@ -1,4 +1,5 @@
 import { DateWithZone } from "../src/datewithzone";
+import rrule from "../src/rrule";
 import { expect } from "chai";
 import { DateTime } from "luxon";
 import { set as setMockDate, reset as resetMockDate } from 'mockdate'
@@ -62,5 +63,16 @@ describe('rezonedDate', () => {
 
     DateTime.fromJSDate = origfromJSDate
     resetMockDate()
+  })
+
+  it('uses custom rezoned date method if specified', () => {
+    const date = new Date(1998, 6, 12)
+    rrule.customRezonedDate = (date, timezone) => date
+
+    const targetZone = 'Europe/Paris'
+    const dt = new DateWithZone(date, targetZone)
+    expect(dt.rezonedDate()).to.deep.equal(date)
+
+    delete rrule.customRezonedDate
   })
 })


### PR DESCRIPTION
Hi, we use date-fns on our project, so we would like to avoid having to load luxon in addition to manage the timezones.
What do you think about the possibility to define a static customRezonedDate method that allows to override the rezonedDate method.

- date-fns-tz example
```
rrule.customRezonedDate = (date, timezone) => dateFnsTz.default.zonedTimeToUtc(date, timezone)`
```
- moment-timezone example
```
rrule.customRezonedDate = (date, timezone) => {
  const formattedDate = moment(date).utc()
  return moment.tz(formattedDate,timezone).toDate()
}
```

It could even be an opportunity to remove the dependency to luxon since this is the only place where it is used.
