### PR TITLE
Remove luxon

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,6 @@ Alternatively, download manually:
 
  * [rrule.min.js](https://jakubroztocil.github.io/rrule/dist/es5/rrule.min.js) (bundled, minified)
  * [rrule.js](https://jakubroztocil.github.io/rrule/dist/es5/rrule.js) (bundled, not minified)
- * [rrule-tz.min.js](https://jakubroztocil.github.io/rrule/dist/es5/rrule-tz.min.js) (with timezone support, bundled, minified)
- * [rrule-tz.js](https://jakubroztocil.github.io/rrule/dist/es5/rrule-tz.js) (with timezone support, bundled, not minified)
 
 ```html
 <script src="rrule/dist/es5/rrule.min.js"></script>
@@ -215,11 +213,11 @@ For more examples see
 
 ### Timezone Support
 
-Optionally, it also supports use of the `TZID` parameter in the
-[RFC](https://tools.ietf.org/html/rfc5545#section-3.2.19)
-when the [Luxon](https://github.com/moment/luxon) library is provided. The 
-[specification](https://moment.github.io/luxon/docs/manual/zones.html#specifying-a-zone)
-and [support matrix](https://moment.github.io/luxon/docs/manual/matrix.html) for Luxon apply.
+Rrule also supports use of the `TZID` parameter in the
+[RFC](https://tools.ietf.org/html/rfc5545#section-3.2.19) using the
+[Intl API](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl).
+Support matrix for the Intl API applies. If you need to support additional environments,
+please consider using a [polyfill](https://formatjs.io/docs/polyfills/).
 
 Example with `TZID`:
 
@@ -336,8 +334,7 @@ iCalendar RFC. Only `freq` is required.
     </tr>
     <tr>
       <td><code>tzid</code></td>
-      <td>If given, this must be a string <a href="https://moment.github.io/luxon/docs/manual/zones.html#specifying-a-zone">supported</a>
-      by Luxon, and the <a href="https://moment.github.io/luxon/">Luxon</a> library must be provided. See
+      <td>If given, this must be a IANA string recognized by the Intl API. See
       discussion under <a href="#timezone-support">Timezone support</a>.
       </td>
     </tr>

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ date.getUTCDate() // --> 1
 date.getUTCHours() // --> 18
 ```
 
-If you want to get the same times in true UTC, you may do so eg. using Luxon:
+If you want to get the same times in true UTC, you may do so eg. using [Luxon](https://moment.github.io/luxon/#/):
 
 ```ts
 rule.all().map(date =>

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "@types/assert": "^1.4.3",
     "@types/chai": "^4.2.7",
     "@types/jquery": "^3.3.29",
-    "@types/luxon": "^1.21.0",
     "@types/mocha": "^5.2.5",
     "@types/mockdate": "^2.0.0",
     "@types/node": "^12.12.18",
@@ -80,9 +79,6 @@
     "dist",
     "README.md"
   ],
-  "optionalDependencies": {
-    "luxon": "^1.21.3"
-  },
   "peerDependencies": {},
   "dependencies": {
     "tslib": "^1.10.0"

--- a/src/datewithzone.ts
+++ b/src/datewithzone.ts
@@ -1,5 +1,4 @@
 import dateutil from './dateutil'
-import { DateTime } from 'luxon'
 
 export class DateWithZone {
   public date: Date
@@ -32,18 +31,11 @@ export class DateWithZone {
       return this.date
     }
 
-    try {
-      const datetime = DateTime
-        .fromJSDate(this.date)
+    const localTimeZone = Intl.DateTimeFormat().resolvedOptions().timeZone
+    const dateInLocalTZ = new Date(this.date.toLocaleString(undefined, { timeZone: localTimeZone }))
+    const dateInTargetTZ = new Date(this.date.toLocaleString(undefined, { timeZone: this.tzid ?? 'UTC' }))
+    const tzOffset = dateInTargetTZ.getTime() - dateInLocalTZ.getTime()
 
-      const rezoned = datetime.setZone(this.tzid!, { keepLocalTime: true })
-
-      return rezoned.toJSDate()
-    } catch (e) {
-      if (e instanceof TypeError) {
-        console.error('Using TZID without Luxon available is unsupported. Returned times are in UTC, not the requested time zone')
-      }
-      return this.date
-    }
+    return new Date(this.date.getTime() - tzOffset)
   }
 }

--- a/test/datewithzone.test.ts
+++ b/test/datewithzone.test.ts
@@ -34,13 +34,13 @@ describe('rezonedDate', () => {
 
   it('returns the date in the correct zone when given', () => {
     const targetZone = 'America/New_York'
-    const currentLocalDate = DateTime.local(2000, 2, 6, 1, 0, 0)
-    setMockDate(currentLocalDate.toJSDate())
+    const currentLocalDate = new Date(2000, 1, 6, 1, 0, 0)
+    setMockDate(currentLocalDate)
 
-    const d = DateTime.fromISO('20101005T110000').toJSDate()
+    const d = new Date(Date.parse('20101005T110000'))
     const dt = new DateWithZone(d, targetZone)
     expect(dt.rezonedDate()).to.deep.equal(
-      expectedDate(DateTime.fromISO('20101005T110000'), currentLocalDate, targetZone)
+      expectedDate(new Date(Date.parse('20101005T110000')), currentLocalDate, targetZone)
     )
 
     resetMockDate()

--- a/test/datewithzone.test.ts
+++ b/test/datewithzone.test.ts
@@ -1,6 +1,5 @@
 import { DateWithZone } from "../src/datewithzone";
 import { expect } from "chai";
-import { DateTime } from "luxon";
 import { set as setMockDate, reset as resetMockDate } from 'mockdate'
 import { expectedDate } from "./lib/utils";
 
@@ -43,24 +42,6 @@ describe('rezonedDate', () => {
       expectedDate(new Date(Date.parse('20101005T110000')), currentLocalDate, targetZone)
     )
 
-    resetMockDate()
-  })
-
-  it('recovers from an error if Luxon is missing', () => {
-    const origfromJSDate = DateTime.fromJSDate
-    DateTime.fromJSDate = () => {
-      throw new TypeError()
-    }
-
-    const targetZone = 'America/New_York'
-    const currentLocalDate = DateTime.local(2000, 2, 6, 1, 0, 0)
-    setMockDate(currentLocalDate.toJSDate())
-
-    const d = DateTime.fromISO('20101005T110000').toJSDate()
-    const dt = new DateWithZone(d, targetZone)
-    expect(dt.rezonedDate()).to.deep.equal(d)
-
-    DateTime.fromJSDate = origfromJSDate
     resetMockDate()
   })
 })

--- a/test/lib/utils.ts
+++ b/test/lib/utils.ts
@@ -195,8 +195,12 @@ testRecurring.skip = function () {
 }
 
 export function expectedDate(startDate: Date, currentLocalDate: Date, targetZone: string): Date {
-  const targetDate = new Date(currentLocalDate.toLocaleString(undefined, { timeZone: targetZone }))
-  const targetOffset = currentLocalDate.getTime() - targetDate.getTime()
+  // get the tzoffset between the client tz and the target tz
+  const localTimeZone = Intl.DateTimeFormat().resolvedOptions().timeZone
+  const dateInLocalTZ = new Date(startDate.toLocaleString(undefined, { timeZone: localTimeZone }))
+  const dateInTargetTZ = new Date(startDate.toLocaleString(undefined, { timeZone: targetZone }))
+  const tzOffset = dateInTargetTZ.getTime() - dateInLocalTZ.getTime()
 
-  return new Date(startDate.getTime() + targetOffset)
+  return new Date(startDate.getTime() - tzOffset)
+  // return new Date(new Date(startDate.getTime() + tzOffset).toLocaleDateString(undefined, { timeZone: localTimeZone }))
 }

--- a/test/lib/utils.ts
+++ b/test/lib/utils.ts
@@ -1,7 +1,6 @@
 import { expect } from 'chai'
 import { ExclusiveTestFunction, TestFunction } from 'mocha'
 import { RRule, RRuleSet } from '../../src'
-import { DateTime } from 'luxon';
 
 const assertDatesEqual = function (actual: Date | Date[], expected: Date | Date[], msg?: string) {
   msg = msg ? ' [' + msg + '] ' : ''
@@ -195,15 +194,9 @@ testRecurring.skip = function () {
   it.skip.apply(it, arguments)
 }
 
-export function expectedDate(startDate: DateTime, currentLocalDate: DateTime, targetZone: string): Date {
-  const targetOffset = startDate.setZone(targetZone).offset
-  const { zoneName: systemZone } = currentLocalDate
-  const {
-    offset: systemOffset,
-  } = startDate.setZone(systemZone)
+export function expectedDate(startDate: Date, currentLocalDate: Date, targetZone: string): Date {
+  const targetDate = new Date(currentLocalDate.toLocaleString(undefined, { timeZone: targetZone }))
+  const targetOffset = currentLocalDate.getTime() - targetDate.getTime()
 
-  const netOffset = targetOffset - systemOffset
-  const hours = -((netOffset / 60) % 24)
-  const minutes = -(netOffset % 60)
-  return startDate.plus({ hours, minutes }).toJSDate()
+  return new Date(startDate.getTime() + targetOffset)
 }

--- a/test/nlp.test.ts
+++ b/test/nlp.test.ts
@@ -1,5 +1,4 @@
 import { expect } from 'chai'
-import { DateTime } from 'luxon'
 import RRule from '../src';
 import { optionsToString } from '../src/optionstostring';
 import {DateFormatter} from '../src/nlp/totext'
@@ -94,7 +93,7 @@ describe('NLP', () => {
   it('by default formats \'until\' correctly', () => {
     const rrule = new RRule({
       freq: RRule.WEEKLY,
-      until: DateTime.utc(2012, 11, 10).toJSDate()
+      until: new Date(Date.UTC(2012, 10, 10))
     })
 
     expect(rrule.toText()).to.equal('every week until November 10, 2012')
@@ -103,7 +102,7 @@ describe('NLP', () => {
   it('formats \'until\' as desired if asked', () => {
     const rrule = new RRule({
       freq: RRule.WEEKLY,
-      until: DateTime.utc(2012, 11, 10).toJSDate()
+      until: new Date(Date.UTC(2012, 10, 10))
     })
 
     const dateFormatter: DateFormatter = (year, month, day) => `${day}. ${month}, ${year}`

--- a/test/rrule.test.ts
+++ b/test/rrule.test.ts
@@ -3647,12 +3647,12 @@ describe('RRule', function () {
     ])
   })
 
-  describe('time zones', () => {
+  describe('time zones, when recurrence is in dst', () => {
     const targetZone = 'America/Los_Angeles'
     const startDate = new Date(Date.UTC(2013, 7, 6, 11, 0, 0))
     const dtstart = startDate
 
-    it('generates correct recurrences when recurrence is in dst and current time is standard time', () => {
+    it('generates correct recurrences when current time is standard time', () => {
       const currentLocalDate = new Date(2013, 1, 6, 11, 0, 0)
       setMockDate(currentLocalDate)
 
@@ -3672,7 +3672,7 @@ describe('RRule', function () {
       resetMockDate()
     })
 
-    it('generates correct recurrences when recurrence is in dst and current time is dst', () => {
+    it('generates correct recurrences when current time is dst', () => {
       const currentLocalDate = new Date(2013, 7, 6, 11, 0, 0)
       setMockDate(currentLocalDate)
 
@@ -3692,7 +3692,7 @@ describe('RRule', function () {
       resetMockDate()
     })
 
-    it('generates correct recurrences when recurrence is in dst and current time is standard time', () => {
+    it('generates correct recurrences using after and current time is standard time', () => {
       const currentLocalDate = new Date(2013, 1, 6, 11, 0, 0)
       setMockDate(currentLocalDate)
 

--- a/test/rrule.test.ts
+++ b/test/rrule.test.ts
@@ -1,9 +1,7 @@
 import { parse, datetime, testRecurring, expectedDate } from './lib/utils'
 import { expect } from 'chai'
 import { RRule, rrulestr, Frequency } from '../src/index'
-import { DateTime } from 'luxon'
 import { set as setMockDate, reset as resetMockDate } from 'mockdate'
-import { optionsToString } from '../src/optionstostring';
 
 describe('RRule', function () {
   // Enable additional toString() / fromString() tests
@@ -3482,7 +3480,7 @@ describe('RRule', function () {
   )
 
   it('testAfterBefore', function () {
-    'YEARLY,MONTHLY,DAILY,HOURLY,MINUTELY,SECONDLY'.split(',').forEach(function (freqStr: keyof typeof Frequency) {
+    (['YEARLY','MONTHLY','DAILY','HOURLY','MINUTELY','SECONDLY'] as const).forEach(function (freqStr: keyof typeof Frequency) {
       const date = new Date(1356991200001)
       const rr = new RRule({
         freq: RRule[freqStr],
@@ -3651,12 +3649,12 @@ describe('RRule', function () {
 
   describe('time zones', () => {
     const targetZone = 'America/Los_Angeles'
-    const startDate = DateTime.utc(2013, 8, 6, 11, 0, 0)
-    const dtstart = startDate.toJSDate()
+    const startDate = new Date(Date.UTC(2013, 7, 6, 11, 0, 0))
+    const dtstart = startDate
 
     it('generates correct recurrences when recurrence is in dst and current time is standard time', () => {
-      const currentLocalDate = DateTime.local(2013, 2, 6, 11, 0, 0)
-      setMockDate(currentLocalDate.toJSDate())
+      const currentLocalDate = new Date(2013, 1, 6, 11, 0, 0)
+      setMockDate(currentLocalDate)
 
       const rule = new RRule({
         dtstart,
@@ -3675,8 +3673,8 @@ describe('RRule', function () {
     })
 
     it('generates correct recurrences when recurrence is in dst and current time is dst', () => {
-      const currentLocalDate = DateTime.local(2013, 8, 6, 11, 0, 0)
-      setMockDate(currentLocalDate.toJSDate())
+      const currentLocalDate = new Date(2013, 7, 6, 11, 0, 0)
+      setMockDate(currentLocalDate)
 
       const rule = new RRule({
         dtstart,
@@ -3695,8 +3693,8 @@ describe('RRule', function () {
     })
 
     it('generates correct recurrences when recurrence is in dst and current time is standard time', () => {
-      const currentLocalDate = DateTime.local(2013, 2, 6, 11, 0, 0)
-      setMockDate(currentLocalDate.toJSDate())
+      const currentLocalDate = new Date(2013, 1, 6, 11, 0, 0)
+      setMockDate(currentLocalDate)
 
       const rule = new RRule({
         dtstart,

--- a/test/rruleset.test.ts
+++ b/test/rruleset.test.ts
@@ -1,6 +1,5 @@
 import { parse, datetime, testRecurring, expectedDate } from './lib/utils'
 import { RRule, RRuleSet, rrulestr, Frequency } from '../src'
-import { DateTime } from 'luxon'
 import { expect } from 'chai'
 import { set as setMockDate, reset as resetMockDate } from 'mockdate'
 
@@ -512,31 +511,31 @@ describe('RRuleSet', function () {
 
     it('generates correcty zoned recurrences when a tzid is present', () => {
       const targetZone = 'America/New_York'
-      const currentLocalDate = DateTime.local(2000, 2, 6, 11, 0, 0)
-      setMockDate(currentLocalDate.toJSDate())
+      const currentLocalDate = new Date(2000, 1, 6, 11, 0, 0)
+      setMockDate(currentLocalDate)
 
       const set = new RRuleSet()
 
       set.rrule(new RRule({
         freq: RRule.YEARLY,
         count: 4,
-        dtstart: DateTime.fromISO('20000101T090000').toJSDate(),
+        dtstart: new Date(Date.UTC(2000, 0, 1, 9, 0, 0)),
         tzid: targetZone
       }))
 
       set.exdate(
-        DateTime.fromISO('20010101T090000').toJSDate(),
+        new Date(Date.UTC(2001, 0, 1, 9, 0, 0)),
       )
 
       set.rdate(
-        DateTime.fromISO('20020301T090000').toJSDate(),
+        new Date(Date.UTC(2002, 2, 1, 9, 0, 0)),
       )     
 
       expect(set.all()).to.deep.equal([
-        expectedDate(DateTime.fromISO('20000101T090000'), currentLocalDate, targetZone),
-        expectedDate(DateTime.fromISO('20020101T090000'), currentLocalDate, targetZone),
-        expectedDate(DateTime.fromISO('20020301T090000'), currentLocalDate, targetZone),
-        expectedDate(DateTime.fromISO('20030101T090000'), currentLocalDate, targetZone),
+        expectedDate(new Date(Date.UTC(2000,0,1,9,0,0)), currentLocalDate, targetZone),
+        expectedDate(new Date(Date.UTC(2002,0,1,9,0,0)), currentLocalDate, targetZone),
+        expectedDate(new Date(Date.UTC(2002,2,1,9,0,0)), currentLocalDate, targetZone),
+        expectedDate(new Date(Date.UTC(2003,0,1,9,0,0)), currentLocalDate, targetZone),
       ])
 
       resetMockDate()
@@ -556,19 +555,19 @@ describe('RRuleSet', function () {
 
     it('generates correcty zoned recurrences when a tzid is present but no rrule is present', () => {
       const targetZone = 'America/New_York'
-      const currentLocalDate = DateTime.local(2000, 2, 6, 11, 0, 0)
-      setMockDate(currentLocalDate.toJSDate())
+      const currentLocalDate = new Date(2000, 1, 6, 11, 0, 0)
+      setMockDate(currentLocalDate)
 
       const set = new RRuleSet()
 
       set.tzid(targetZone)
 
       set.rdate(
-        DateTime.fromISO('20020301T090000').toJSDate(),
+        new Date(Date.parse('20020301T090000')),
       )
 
       expect(set.all()).to.deep.equal([
-        expectedDate(DateTime.fromISO('20020301T090000'), currentLocalDate, targetZone)
+        expectedDate(new Date(Date.parse('20020301T090000')), currentLocalDate, targetZone)
       ])
 
       resetMockDate()
@@ -576,17 +575,17 @@ describe('RRuleSet', function () {
   })
 
   describe('with end date', () => {
-    let cursor: DateTime
+    let cursor: Date
 
     beforeEach(() => {
-      cursor = DateTime.utc(2017, 12, 25, 16, 0, 0)
+      cursor = new Date(Date.UTC(2017, 11, 25, 16, 0, 0))
     })
 
     it('updates the ruleset to exclude recurrence date', () => {
       const legacy = ['RRULE:DTSTART=19990104T110000Z;FREQ=DAILY;INTERVAL=1']
       const repeat = ['DTSTART:19990104T110000Z', 'RRULE:FREQ=DAILY;INTERVAL=1']
 
-      const recurrenceDate = DateTime.utc(2017, 8, 21, 16, 0, 0)
+      const recurrenceDate = new Date(Date.UTC(2017, 7, 21, 16, 0, 0))
 
       expectRecurrence([repeat, legacy]).toAmendExdate(recurrenceDate, [
         'DTSTART:19990104T110000Z',
@@ -655,16 +654,23 @@ describe('RRuleSet', function () {
 
     const updateWithEndDate = (
       recurrence: string[],
-      updatedCursor: DateTime,
+      updatedCursor: Date,
     ): string => {
-      const newEndDate = updatedCursor.minus({ days: 1 }).endOf('day')
+      const oneDay = 24 * 60 * 60 * 1000
+      const oneDayEarlier = new Date(updatedCursor.getTime() - oneDay)
+      const newEndDate = new Date(Date.UTC(
+        oneDayEarlier.getUTCFullYear(),
+        oneDayEarlier.getUTCMonth(),
+        oneDayEarlier.getUTCDate(),
+        23, 59, 59
+      ))
 
       const rrule = rrulestr(recurrence.join('\n'))
 
       const newRuleSet = new RRuleSet()
       const rule = new RRule({
           ...rrule.origOptions,
-          until: newEndDate.toJSDate(),
+          until: newEndDate,
         })
 
       newRuleSet.rrule(rule)
@@ -674,10 +680,10 @@ describe('RRuleSet', function () {
 
     const amendRuleSetWithExceptionDate = (
       recurrence: string[],
-      cursor: DateTime,
+      cursor: Date,
     ): string => {
       const ruleSet = rrulestr(recurrence.join('\n'), { forceset: true }) as RRuleSet
-      ruleSet.exdate(cursor.toJSDate())
+      ruleSet.exdate(cursor)
       return ruleSet.toString()
     }
 
@@ -698,7 +704,7 @@ describe('RRuleSet', function () {
             expect(actual).to.equal(expected.join('\n'))
           })
         },
-        toAmendExdate(excluded: DateTime, expected: string[]) {
+        toAmendExdate(excluded: Date, expected: string[]) {
           recurrences.forEach(recurrence => {
             const actual = amendRuleSetWithExceptionDate(recurrence, excluded)
             expect(actual).to.equal(expected.join('\n'))

--- a/test/rruleset.test.ts
+++ b/test/rruleset.test.ts
@@ -720,7 +720,7 @@ describe('RRuleSet', function () {
     }
   })
 
-  it('generates invalid date objects on an rruleset with invalid TZID and exdate', () => {
+  it('throws a RangeError on an rruleset with invalid TZID and exdate', () => {
     const set = new RRuleSet()
     set.rrule(new RRule({
       count: 1,
@@ -729,9 +729,7 @@ describe('RRuleSet', function () {
     }))
     set.exdate(parse('19970902T090000'))
 
-    expect(set.all().map(String)).to.deep.equal([
-      'Invalid Date'
-    ])
+    expect(() => set.all().map(String)).to.throw(RangeError)
   })
 
   it('throws an error if non-rrules are added via rrule or exrule', () => {

--- a/test/rruleset.test.ts
+++ b/test/rruleset.test.ts
@@ -529,7 +529,7 @@ describe('RRuleSet', function () {
 
       set.rdate(
         new Date(Date.UTC(2002, 2, 1, 9, 0, 0)),
-      )     
+      )
 
       expect(set.all()).to.deep.equal([
         expectedDate(new Date(Date.UTC(2000,0,1,9,0,0)), currentLocalDate, targetZone),

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -54,16 +54,6 @@ const rruleConfig = Object.assign({
     rrule: path.join(paths.source, "index.ts"),
     'rrule.min': path.join(paths.source, "index.ts")
   },
-  plugins: [
-    new webpack.NormalModuleReplacementPlugin(/^luxon$/, './fake-luxon.ts'),
-  ]
-}, commonConfig);
-
-const rruleWithLuxonConfig = Object.assign({
-  entry: {
-    'rrule-tz': path.join(paths.source, "index.ts"),
-    'rrule-tz.min': path.join(paths.source, "index.ts")
-  },
 }, commonConfig);
 
 const demoConfig = {
@@ -110,4 +100,4 @@ const demoConfig = {
   mode: "production"
 };
 
-module.exports = [rruleConfig, rruleWithLuxonConfig, demoConfig];
+module.exports = [rruleConfig, demoConfig];

--- a/yarn.lock
+++ b/yarn.lock
@@ -120,11 +120,6 @@
   dependencies:
     "@types/sizzle" "*"
 
-"@types/luxon@^1.21.0":
-  version "1.21.0"
-  resolved "https://registry.yarnpkg.com/@types/luxon/-/luxon-1.21.0.tgz#db792d29f535d49522cb6d94dd9da053efc950a1"
-  integrity sha512-Zhrf65tpjOlVIYrUhX9eu1VzRo8iixQDLFPbfqFxPpG4pBTNNPZ2BFhYE0IAsDfW9GWg+RcrUqiLwrGJH4rq4w==
-
 "@types/mocha@^5.2.5":
   version "5.2.5"
   resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-5.2.5.tgz#8a4accfc403c124a0bafe8a9fc61a05ec1032073"
@@ -2409,11 +2404,6 @@ lru-cache@^5.1.1:
   integrity sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==
   dependencies:
     yallist "^3.0.2"
-
-luxon@^1.21.3:
-  version "1.21.3"
-  resolved "https://registry.yarnpkg.com/luxon/-/luxon-1.21.3.tgz#f1d5c2a7e855d039836cf4954f883ecac8fc4727"
-  integrity sha512-lLRwNcNnkZLuv13A1FUuZRZmTWF7ro2ricYvb0L9cvBYHPvZhQdKwrYnZzi103D2XKmlVmxWpdn2wfIiOt2YEw==
 
 make-dir@^2.0.0, make-dir@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
Addresses https://github.com/jakubroztocil/rrule/issues/501

Note it is now possible to avoid using any 3rd party dependency, since browser support for the `Intl` API is now fairly widespread.