### PR TITLE
Point to esm correctly

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
   ],
   "author": "Jakub Roztocil, Lars Schöning, and David Golightly",
   "main": "dist/es5/rrule.js",
-  "module": "dist/esm/src/index.js",
-  "types": "dist/esm/src/index.d.ts",
+  "module": "dist/esm/index.js",
+  "types": "dist/esm/index.d.ts",
   "repository": {
     "type": "git",
     "url": "git://github.com/jakubroztocil/rrule.git"


### PR DESCRIPTION
[My previous PR](https://github.com/jakubroztocil/rrule/pull/510/files) to remove demo unexpectedly changed dist/esm folder structure.
It is very unexpected. I looked up and down my change but I cannot even explain what caused the change.
So here I'm simply fixing the `package.json`

Before:
<img width="533" alt="image" src="https://user-images.githubusercontent.com/1072766/172738276-7cae29a9-3804-4715-90e0-682e1f630307.png">

After:
<img width="564" alt="image" src="https://user-images.githubusercontent.com/1072766/172737581-2f1e4e52-7273-4e21-96a3-0cd63307e148.png">


---

### Thanks for contributing to `rrule`!

To submit a pull request, please verify that you have done the following:

- [x] Merged in or rebased on the latest `master` commit
- [x] Linked to an existing bug or issue describing the bug or feature you're
      addressing
- [N/A] Written one or more tests showing that your change works as advertised
