### PR TITLE
Until date string should always be in UTC.

### DIFF
--- a/src/optionstostring.ts
+++ b/src/optionstostring.ts
@@ -67,7 +67,7 @@ export function optionsToString(options: Partial<Options>) {
         break
 
       case 'UNTIL':
-        outValue = timeToUntilString(value as number, !options.tzid)
+        outValue = timeToUntilString(value as number)
         break
 
       default:

--- a/test/rruleset.test.ts
+++ b/test/rruleset.test.ts
@@ -715,7 +715,7 @@ describe('RRuleSet', function () {
       expectRecurrence([original, legacy]).toBeUpdatedWithEndDate(
         [
           'DTSTART;TZID=America/New_York:20171201T080000',
-          'RRULE:FREQ=WEEKLY;UNTIL=20171224T235959',
+          'RRULE:FREQ=WEEKLY;UNTIL=20171224T235959Z',
         ].join('\n')
       )
     })


### PR DESCRIPTION
In the current behavior, the `until` date string is in UTC iff the `TZID` is not specified. According to the [RRule spec](https://datatracker.ietf.org/doc/html/rfc5545):
> If the "DTSTART" property is specified as a date with UTC time or a date with local time and time zone reference, then the UNTIL rule part MUST be specified as a date with UTC time.

By this spec, the `until` date string should be in UTC if the converse is true - i.e. `TZID` _is_ specified. So we should always use UTC for `until`.

Note that [python-dateutil](http://labix.org/python-dateutil/) library actually throws an error if `TZID` is specified for `dtstart` and `until` is not in UTC [according to StackOverflow](https://stackoverflow.com/questions/53997143/valueerror-rrule-until-values-must-be-specified-in-utc-when-dtstart-is-timezone).