### PR TITLE
Fixing failed to parse source map warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,8 @@
   },
   "files": [
     "dist",
-    "README.md"
+    "README.md",
+    "src/**"
   ],
   "peerDependencies": {},
   "dependencies": {


### PR DESCRIPTION
When building the library the src types weren't included in the build wich
cased warning and failing to parse source map as files were not found.
This PR includes src folder in the building directory.

---

### Thanks for contributing to `rrule`!

To submit a pull request, please verify that you have done the following:

- [ ] Merged in or rebased on the latest `master` commit
- [ ] Linked to an existing bug or issue describing the bug or feature you're
      addressing
- [ ] Written one or more tests showing that your change works as advertised
