### PR TITLE
fix rezonedDate without luxon (commit: cf76af3)

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -14,8 +14,8 @@ jobs:
       - run: npm install -g codecov nyc
       - run: yarn install
       - run: yarn build
-      - run: TZ=America/Vancouver yarn test
-      - run: TZ=America/Los_Angeles yarn test
-      - run: TZ=Africa/Nairobi yarn test
-      - run: TZ=Asia/Tokyo yarn test-ci
+      - run: LANG=en_CA TZ=America/Vancouver yarn test
+      - run: LANG=en_US TZ=America/Los_Angeles yarn test
+      - run: LANG=sw_KE TZ=Africa/Nairobi yarn test
+      - run: LANG=jp_JP TZ=Asia/Tokyo yarn test-ci
       - run: nyc report --reporter=json && codecov -t ${{ secrets.CODECOV_REPO_TOKEN }} -f coverage/*.json

--- a/src/dateutil.ts
+++ b/src/dateutil.ts
@@ -201,3 +201,20 @@ export const untilStringToDate = function (until: string) {
     )
   )
 }
+
+const dateTZtoISO8601 = function (date: Date, timeZone: string) {
+  // date format for sv-SE is almost ISO8601
+  const dateStr = date.toLocaleString('sv-SE', { timeZone })
+  // '2023-02-07 10:41:36'
+  return dateStr.replace(' ', 'T') + 'Z'
+}
+
+export const dateInTimeZone = function (date: Date, timeZone: string) {
+  const localTimeZone = Intl.DateTimeFormat().resolvedOptions().timeZone
+  // Date constructor can only reliably parse dates in ISO8601 format
+  const dateInLocalTZ = new Date(dateTZtoISO8601(date, localTimeZone))
+  const dateInTargetTZ = new Date(dateTZtoISO8601(date, timeZone ?? 'UTC'))
+  const tzOffset = dateInTargetTZ.getTime() - dateInLocalTZ.getTime()
+
+  return new Date(date.getTime() - tzOffset)
+}

--- a/src/datewithzone.ts
+++ b/src/datewithzone.ts
@@ -36,10 +36,10 @@ export class DateWithZone {
 
     const localTimeZone = Intl.DateTimeFormat().resolvedOptions().timeZone
     const dateInLocalTZ = new Date(
-      this.date.toLocaleString(undefined, { timeZone: localTimeZone })
+      this.date.toLocaleString('en-US', { timeZone: localTimeZone })
     )
     const dateInTargetTZ = new Date(
-      this.date.toLocaleString(undefined, { timeZone: this.tzid ?? 'UTC' })
+      this.date.toLocaleString('en-US', { timeZone: this.tzid ?? 'UTC' })
     )
     const tzOffset = dateInTargetTZ.getTime() - dateInLocalTZ.getTime()
 

--- a/src/datewithzone.ts
+++ b/src/datewithzone.ts
@@ -34,13 +34,17 @@ export class DateWithZone {
       return this.date
     }
 
+    const dateTZtoISO8601 = (date: Date, timeZone: string) => {
+      // date format for sv-SE is almost ISO8601
+      const dateStr = date.toLocaleString('sv-SE', { timeZone })
+      // '2023-02-07 10:41:36'
+      return dateStr.replace(' ', 'T') + 'Z'
+    }
+
     const localTimeZone = Intl.DateTimeFormat().resolvedOptions().timeZone
-    const dateInLocalTZ = new Date(
-      this.date.toLocaleString('en-US', { timeZone: localTimeZone })
-    )
-    const dateInTargetTZ = new Date(
-      this.date.toLocaleString('en-US', { timeZone: this.tzid ?? 'UTC' })
-    )
+    // Date constructor can only reliably parse dates in ISO8601 format
+    const dateInLocalTZ = new Date(dateTZtoISO8601(this.date, localTimeZone))
+    const dateInTargetTZ = new Date(dateTZtoISO8601(this.date, this.tzid ?? 'UTC'))
     const tzOffset = dateInTargetTZ.getTime() - dateInLocalTZ.getTime()
 
     return new Date(this.date.getTime() - tzOffset)

--- a/src/datewithzone.ts
+++ b/src/datewithzone.ts
@@ -1,4 +1,4 @@
-import { timeToUntilString } from './dateutil'
+import { dateInTimeZone, timeToUntilString } from './dateutil'
 
 export class DateWithZone {
   public date: Date
@@ -34,21 +34,6 @@ export class DateWithZone {
       return this.date
     }
 
-    const dateTZtoISO8601 = (date: Date, timeZone: string) => {
-      // date format for sv-SE is almost ISO8601
-      const dateStr = date.toLocaleString('sv-SE', { timeZone })
-      // '2023-02-07 10:41:36'
-      return dateStr.replace(' ', 'T') + 'Z'
-    }
-
-    const localTimeZone = Intl.DateTimeFormat().resolvedOptions().timeZone
-    // Date constructor can only reliably parse dates in ISO8601 format
-    const dateInLocalTZ = new Date(dateTZtoISO8601(this.date, localTimeZone))
-    const dateInTargetTZ = new Date(
-      dateTZtoISO8601(this.date, this.tzid ?? 'UTC')
-    )
-    const tzOffset = dateInTargetTZ.getTime() - dateInLocalTZ.getTime()
-
-    return new Date(this.date.getTime() - tzOffset)
+    return dateInTimeZone(this.date, this.tzid)
   }
 }

--- a/src/datewithzone.ts
+++ b/src/datewithzone.ts
@@ -44,7 +44,9 @@ export class DateWithZone {
     const localTimeZone = Intl.DateTimeFormat().resolvedOptions().timeZone
     // Date constructor can only reliably parse dates in ISO8601 format
     const dateInLocalTZ = new Date(dateTZtoISO8601(this.date, localTimeZone))
-    const dateInTargetTZ = new Date(dateTZtoISO8601(this.date, this.tzid ?? 'UTC'))
+    const dateInTargetTZ = new Date(
+      dateTZtoISO8601(this.date, this.tzid ?? 'UTC')
+    )
     const tzOffset = dateInTargetTZ.getTime() - dateInLocalTZ.getTime()
 
     return new Date(this.date.getTime() - tzOffset)

--- a/test/lib/utils.ts
+++ b/test/lib/utils.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai'
 import { ExclusiveTestFunction, TestFunction } from 'mocha'
 export { datetime } from '../../src/dateutil'
-import { datetime } from '../../src/dateutil'
+import { dateInTimeZone, datetime } from '../../src/dateutil'
 import { RRule, RRuleSet } from '../../src'
 
 const assertDatesEqual = function (
@@ -239,16 +239,5 @@ export function expectedDate(
   currentLocalDate: Date,
   targetZone: string
 ): Date {
-  // get the tzoffset between the client tz and the target tz
-  const localTimeZone = Intl.DateTimeFormat().resolvedOptions().timeZone
-  const dateInLocalTZ = new Date(
-    startDate.toLocaleString(undefined, { timeZone: localTimeZone })
-  )
-  const dateInTargetTZ = new Date(
-    startDate.toLocaleString(undefined, { timeZone: targetZone })
-  )
-  const tzOffset = dateInTargetTZ.getTime() - dateInLocalTZ.getTime()
-
-  return new Date(startDate.getTime() - tzOffset)
-  // return new Date(new Date(startDate.getTime() + tzOffset).toLocaleDateString(undefined, { timeZone: localTimeZone }))
+  return dateInTimeZone(startDate, targetZone)
 }

--- a/test/rrule.test.ts
+++ b/test/rrule.test.ts
@@ -165,7 +165,7 @@ describe('RRule', function () {
         freq: RRule.WEEKLY,
         dtstart: parse('20220613T090000'),
         byweekday: [RRule.TU],
-        tzid: 'Europe/London'
+        tzid: 'Europe/London',
       }),
       method: 'between',
       args: [parse('20220613T093000'), parse('20220716T083000')],

--- a/test/rrule.test.ts
+++ b/test/rrule.test.ts
@@ -159,6 +159,27 @@ describe('RRule', function () {
   )
 
   testRecurring(
+    'testBetweenWithTZ',
+    {
+      rrule: new RRule({
+        freq: RRule.WEEKLY,
+        dtstart: parse('20220613T090000'),
+        byweekday: [RRule.TU],
+        tzid: 'Europe/London'
+      }),
+      method: 'between',
+      args: [parse('20220613T093000'), parse('20220716T083000')],
+    },
+    [
+      datetime(2022, 6, 14, 9, 0),
+      datetime(2022, 6, 21, 9, 0),
+      datetime(2022, 6, 28, 9, 0),
+      datetime(2022, 7, 5, 9, 0),
+      datetime(2022, 7, 12, 9, 0),
+    ]
+  )
+
+  testRecurring(
     'testYearly',
     new RRule({
       freq: RRule.YEARLY,

--- a/test/rrule.test.ts
+++ b/test/rrule.test.ts
@@ -171,11 +171,11 @@ describe('RRule', function () {
       args: [parse('20220613T093000'), parse('20220716T083000')],
     },
     [
-      datetime(2022, 6, 14, 9, 0),
-      datetime(2022, 6, 21, 9, 0),
-      datetime(2022, 6, 28, 9, 0),
-      datetime(2022, 7, 5, 9, 0),
-      datetime(2022, 7, 12, 9, 0),
+      expectedDate(datetime(2022, 6, 14, 9, 0), undefined, 'Europe/London'),
+      expectedDate(datetime(2022, 6, 21, 9, 0), undefined, 'Europe/London'),
+      expectedDate(datetime(2022, 6, 28, 9, 0), undefined, 'Europe/London'),
+      expectedDate(datetime(2022, 7, 5, 9, 0), undefined, 'Europe/London'),
+      expectedDate(datetime(2022, 7, 12, 9, 0), undefined, 'Europe/London'),
     ]
   )
 


### PR DESCRIPTION
fixes https://github.com/jakubroztocil/rrule/issues/523

The problem was introduced in https://github.com/jakubroztocil/rrule/pull/508 by commit: https://github.com/jakubroztocil/rrule/commit/cf76af345f02dd1122a432acb5a85a7236b99228 in `src/datewithzone.ts`:

```
const dateInLocalTZ = new Date(this.date.toLocaleString(undefined, { timeZone: localTimeZone }))
```
This relies on `new Date()` parsing the output of `date.toLocaleString()`, but it _only_ recognizes month/day/year, i.e. US date format. As the first parameter of `date.toLocaleString()` is `undefined`, the output will be in the host's locale. As I'm in London, that is en-GB which formats the date as day/month/year which causes `new Date()` to return `Invalid Date`.

The solution is to explicitly specify the `en-US` locale instead of `undefined`.



---

### Thanks for contributing to `rrule`!

To submit a pull request, please verify that you have done the following:

- [x ] Merged in or rebased on the latest `master` commit
- [x ] Linked to an existing bug or issue describing the bug or feature you're
      addressing
- [x ] Written one or more tests showing that your change works as advertised
